### PR TITLE
fix(footer): properly set the path prefix of the contribution link

### DIFF
--- a/src/gatsby-theme-carbon/components/Footer.js
+++ b/src/gatsby-theme-carbon/components/Footer.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { withPrefix } from "gatsby";
 import Footer from "gatsby-theme-carbon/src/components/Footer";
 
 /**
@@ -33,7 +34,7 @@ const CustomFooter = () => {
    */
   const links = {
     firstCol: [
-      { href: "/contributions", linkText: "Contribute" },
+      { href: withPrefix("/contributions"), linkText: "Contribute" },
       { href: "https://www.ibm.com/privacy", linkText: "Privacy" },
       { href: "https://www.ibm.com/legal", linkText: "Terms of use" },
       { href: "https://ibm.com", linkText: "IBM.com" },


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Adding a fix to properly set the path prefix for the contribution link in the footer.

### Changelog

**Changed**

- added `withPrefix` constructor to the footer link
