### PR TITLE
docs(slack): rename to #carbon-for-ibm-dotcom

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -12,7 +12,7 @@ share a couple resources that you could use if you haven't tried them yet 🙂.
 If you're an IBMer, we have a couple of Slack channels available across all IBM
 Workspaces:
 
-- #ibm-digital-design for questions about Carbon for IBM.com
+- #carbon-for-ibm-dotcom for questions about Carbon for IBM.com
 - #carbon-design-system for questions about the Design System
 - #carbon-components for questions about component styles
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -12,7 +12,7 @@ import {
 
 const links = [
   { href: '/help', text: 'Help' },
-  { href: 'https://ibm-studios.slack.com/archives/C2PLX8GQ6', text: '#ibm-digital-design' },
+  { href: 'https://ibm-studios.slack.com/archives/C2PLX8GQ6', text: '#carbon-for-ibm-dotcom' },
   { href: 'https://www.github.com/carbon-design-system/carbon-for-ibm-dotcom', text: 'Github Repo' },
 ];
 

--- a/src/pages/contributions/components.mdx
+++ b/src/pages/contributions/components.mdx
@@ -81,9 +81,9 @@ issue in the
 
 #### 4. Usage documentation
 
-For guidance, see our Documentation requirements section above or reach out to us on <a href="https://ibm-studios.slack.com/archives/C2PLX8GQ6" target="_blank">#ibm-digital-design</a>.
+For guidance, see our Documentation requirements section above or reach out to us on <a href="https://ibm-studios.slack.com/archives/C2PLX8GQ6" target="_blank">#carbon-for-ibm-dotcom</a>.
 
 #### 5. Working code
 
-The component for **Carbon for IBM.com** must be built in one of our supported frameworks - React or Web Components.  We'd like to prioritize working on Web Components since it has become our strategic direction.  If you need help learning how to build it in Web Components, reach out to the engineers in our slack channel for training <a href="https://ibm-studios.slack.com/archives/C2PLX8GQ6" target="_blank">#ibm-digital-design</a>.  Please read the [Developer guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/developing.md) and the [Submissions guidelines](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/submission-guidelines.md) for more details.
+The component for **Carbon for IBM.com** must be built in one of our supported frameworks - React or Web Components.  We'd like to prioritize working on Web Components since it has become our strategic direction.  If you need help learning how to build it in Web Components, reach out to the engineers in our slack channel for training <a href="https://ibm-studios.slack.com/archives/C2PLX8GQ6" target="_blank">#carbon-for-ibm-dotcom</a>.  Please read the [Developer guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/developing.md) and the [Submissions guidelines](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/submission-guidelines.md) for more details.
 

--- a/src/pages/get-started/index.mdx
+++ b/src/pages/get-started/index.mdx
@@ -61,7 +61,7 @@ This site explains how to get started with Carbon for IBM.com. It provides links
 * Carbon has a new 2x grid so everything needs to be designed understanding that grid.
 * It is open source, so any adopters are invited to contribute to the open source Carbon for IBM.com.
 
-To assist adopters through this transition, Digital Design can guide a team as they are getting started or if they want a code review. Reach out on our slack channel at [#ibm-digital-design](https://ibm-studios.slack.com/archives/C2PLX8GQ6).
+To assist adopters through this transition, Digital Design can guide a team as they are getting started or if they want a code review. Reach out on our slack channel at [#carbon-for-ibm-dotcom](https://ibm-studios.slack.com/archives/C2PLX8GQ6).
 
 ## Resources 
 

--- a/src/pages/guidelines/style-models/overview.mdx
+++ b/src/pages/guidelines/style-models/overview.mdx
@@ -132,8 +132,8 @@ There are currently 9 user intents identified so far, each with an associated st
 
 1. Identify the user intent that matches that of the page to be designed.
 2. Use the associated style model as the starting point for design.
-3. Contact the Digital Design System squad for updates via <a href="https://cognitive-app.slack.com/archives/C2PLX8GQ6" target="_blank">#ibm-digital-design</a> Slack channel.
+3. Contact the Digital Design System squad for updates via <a href="https://cognitive-app.slack.com/archives/C2PLX8GQ6" target="_blank">#carbon-for-ibm-dotcom</a> Slack channel.
 
 <Title>Feedback</Title>
 
-These user intents and style models are not set in stone—they and are intended to evolve over time. If for any reason, the existing user intents or style models do not meet the user needs, please contact the Digital Design System team via the <a href="https://cognitive-app.slack.com/archives/C2PLX8GQ6" target="_blank">#ibm-digital-design</a> slack channel.
+These user intents and style models are not set in stone—they and are intended to evolve over time. If for any reason, the existing user intents or style models do not meet the user needs, please contact the Digital Design System team via the <a href="https://cognitive-app.slack.com/archives/C2PLX8GQ6" target="_blank">#carbon-for-ibm-dotcom</a> slack channel.

--- a/src/pages/guidelines/style-models/style-model-list.mdx
+++ b/src/pages/guidelines/style-models/style-model-list.mdx
@@ -13,7 +13,7 @@ The primary user intent drives the foundational structure of any given page defi
 
 ## User intents and style models
 
-These user intents and style models are not set in stone—they and are intended to evolve over time. If for any reason, the existing user intents or style models do not meet the user needs, please contact the Digital Design System team via the <a href="https://cognitive-app.slack.com/archives/C2PLX8GQ6" target="_blank">#ibm-digital-design</a> slack channel.
+These user intents and style models are not set in stone—they and are intended to evolve over time. If for any reason, the existing user intents or style models do not meet the user needs, please contact the Digital Design System team via the <a href="https://cognitive-app.slack.com/archives/C2PLX8GQ6" target="_blank">#carbon-for-ibm-dotcom</a> slack channel.
 
 <br/>
 

--- a/src/pages/help/faqs.mdx
+++ b/src/pages/help/faqs.mdx
@@ -30,7 +30,7 @@ In order to stay current with what’s coming, read the [Release Schedule]( http
 
 ### Where can I get current information?
 * For information on the rollout schedule, see the [Roadmap](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/wiki/Roadmap) on our Github.  
-* For announcements, join the [#ibm-digital-design](https://ibm-studios.slack.com/archives/C2PLX8GQ6) Slack channel.
+* For announcements, join the [#carbon-for-ibm-dotcom](https://ibm-studios.slack.com/archives/C2PLX8GQ6) Slack channel.
 * For design guidelines, see the [Designing](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/get-started/designing) page.
 * For coding guidelines, see the [Coding](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/get-started/coding) page.
 * For guidance regarding overall expression, review the [IBM Design Language](https://www.ibm.com/design/language/).
@@ -42,7 +42,7 @@ Please open an [issue]( https://github.com/carbon-design-system/carbon-for-ibm-d
 Please open an [issue]( https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose) under **"Bug Report"** in our Github repo. We will evaluate the bug in our weekly triage meeting. If you have a fix for the bug, please feel free to submit a PR for it in the Github repository.
 
 ### Where do I go if I’ve read everything and still have an issue/question?
-Ask on the [#ibm-digital-design](https://cognitive-app.slack.com/archives/C2PLX8GQ6) Slack channel or open an [issue]( https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose) under **"Question"** in our Github repo.
+Ask on the [#carbon-for-ibm-dotcom](https://cognitive-app.slack.com/archives/C2PLX8GQ6) Slack channel or open an [issue]( https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose) under **"Question"** in our Github repo.
 
 ### When will the Expressive Theme be available in Carbon for IBM.com use?
 We are working on the integration detail.  We will provide updates on our [Roadmap](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/wiki/Roadmap) on our Github.

--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -28,7 +28,7 @@ Answers to the most common questions about the design system can be found in the
 ### Slack channels
 _Internal IBM users only. The Carbon for IBM.com core team maintains the following channels and will provide support as time permits._
 
-**Please try searching the Slack channel for your topic first.** Slack’s filtering feature will return more targeted and relevant results. For instance, if you have a technical question about the DataTable component, you could search “DataTable” in Slack and then filter by the #ibm-digital-design channel. 
+**Please try searching the Slack channel for your topic first.** Slack’s filtering feature will return more targeted and relevant results. For instance, if you have a technical question about the DataTable component, you could search “DataTable” in Slack and then filter by the #carbon-for-ibm-dotcom channel. 
 
 _Tip: You can start a new search directly from the message box using the /s slash command._
 
@@ -58,7 +58,7 @@ Bug reports, feature requests, and general feedback can be delivered to the Carb
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="For coding and designing questions: #ibm-digital-design"
+      subTitle="For coding and designing questions: #carbon-for-ibm-dotcom"
       aspectRatio="2:1"
       actionIcon="launch"
       href="https://ibm-studios.slack.com/archives/C2PLX8GQ6"

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -336,7 +336,7 @@ Carbon for IBM.com delivers the [IBM Design Language](https://www.ibm.com/design
   
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="For coding and designing questions: #ibm-digital-design"
+      subTitle="For coding and designing questions: #carbon-for-ibm-dotcom"
       href="https://ibm-studios.slack.com/archives/C2PLX8GQ6"
     >
 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This is a PR to rename all of the instances of the `#ibm-digital-design` slack channel and changing to `#carbon-for-ibm-dotcom`.

### Changelog

**Changed**

- Slack channel rename to `#carbon-for-ibm-dotcom`
