### PR TITLE
fix(cla): minor fix to team name

### DIFF
--- a/src/pages/contributions/overview.mdx
+++ b/src/pages/contributions/overview.mdx
@@ -71,4 +71,4 @@ Carbon for IBM.com projects typically use a [fork and pull request workflow](htt
 
 ## Contributor License Agreement
 
-IBM.com Library team works for IBM. To accept contributions outside of IBM, we need a signed Contributor License Agreement (CLA) from you before code contributions can be reviewed and merged. If you have any questions, please don’t hesitate to reach out.
+Carbon for IBM.com team works for IBM. To accept contributions outside of IBM, we need a signed Contributor License Agreement (CLA) from you before code contributions can be reviewed and merged. If you have any questions, please don’t hesitate to reach out.


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This is a minor documentation fix that changes to the new team name.

### Changelog

**Changed**

- CLA text