### PR TITLE
feat(homepage): change pictograms on resource cards to 64px

### DIFF
--- a/src/styles/_feature-card-group.scss
+++ b/src/styles/_feature-card-group.scss
@@ -2,8 +2,8 @@
   &.resource-card-group .#{$prefix}--resource-card__icon--img {
     bottom: 0;
     left: 0;
-    height: 116px;
-    width: 116px;
+    height: 64px;
+    width: 64px;
 
     img {
       width: 100%;


### PR DESCRIPTION
### Related Ticket(s)

[Update pictograms on the homepage #4545](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/4545)

### Description

Update pictograms on the "Latest Updates" cards to 64px X 64px

