### PR TITLE
feat(component-description): add ComponentDescription to component pages

### DIFF
--- a/src/components/ComponentDescription/ComponentDescription.js
+++ b/src/components/ComponentDescription/ComponentDescription.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PageDescription from 'gatsby-theme-carbon/src/components/PageDescription';
+import P from 'gatsby-theme-carbon/src/components/markdown/P';
+import components from '../../data/components.json';
+
+/**
+ * Returns the description of the component as a PageDescription block
+ *
+ * @param {string} name Name of the component
+ * @param {string} type Type of component (ui|layout)
+ * @returns {*} Component description
+ * @constructor
+ */
+export const ComponentDescription = ({ name, type }) => (
+  <PageDescription>
+    <P dangerouslySetInnerHTML={{ __html: components[type][name].description }} />
+  </PageDescription>
+);

--- a/src/components/ComponentDescription/index.js
+++ b/src/components/ComponentDescription/index.js
@@ -1,0 +1,3 @@
+import { ComponentDescription } from './ComponentDescription';
+
+export default ComponentDescription;

--- a/src/components/ComponentFeedback/ComponentFeedback.js
+++ b/src/components/ComponentFeedback/ComponentFeedback.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import P from 'gatsby-theme-carbon/src/components/markdown/P';
+
+/**
+ * Feedback content at the end of a component page
+ *
+ * @returns {JSX.Element} Component feedback
+ * @constructor
+ */
+export const ComponentFeedback = () => (
+  <P>
+      Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+  </P>
+);

--- a/src/components/ComponentFeedback/index.js
+++ b/src/components/ComponentFeedback/index.js
@@ -1,0 +1,3 @@
+import { ComponentFeedback } from './ComponentFeedback';
+
+export default ComponentFeedback;

--- a/src/gatsby-theme-carbon/components/Footer.js
+++ b/src/gatsby-theme-carbon/components/Footer.js
@@ -21,7 +21,7 @@ const CustomFooter = () => {
         .
       </p>
       <p>
-        Last updated August 6th, 2020
+        Last updated December 16th, 2020
         <br />
         Copyright &copy; 2020 IBM
       </p>

--- a/src/pages/components/button-group.mdx
+++ b/src/pages/components/button-group.mdx
@@ -4,12 +4,10 @@ description: The Button group component is to be utilized within IBM.com for gro
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Button group component is to be utilized within IBM.com for grouping two or more Button components together and sets all buttons to the same width.
-
-</PageDescription>
+<ComponentDescription name="Button Group" type="ui" />
 
 <AnchorLinks>
   
@@ -30,5 +28,5 @@ The design specs and functional specs for the Button group can be viewed <a href
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />
 

--- a/src/pages/components/callout-quote.mdx
+++ b/src/pages/components/callout-quote.mdx
@@ -4,12 +4,10 @@ description: The callout quote is a typographic pattern that is used to highligh
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Callout &mdash; quote is a typographic pattern that is used to highlight an impactful client statement or user testimonial.
-
-</PageDescription>
+<ComponentDescription name="Callout - quote" type="layout" />
 
 <AnchorLinks>
 
@@ -35,4 +33,4 @@ The design specs and functional specs for the Callout &mdash; quote pattern can 
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/callout-with-media.mdx
+++ b/src/pages/components/callout-with-media.mdx
@@ -4,12 +4,10 @@ description: Callout &mdash; with media is used to feature a high value media as
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Callout &mdash; with media is used to feature a high value media asset such as a customer story. 
-
-</PageDescription>
+<ComponentDescription name="Callout - with media" type="layout" />
 
 <AnchorLinks>
 
@@ -35,4 +33,4 @@ The design specs and functional specs for Callout — with media can be viewed <
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/card-group.mdx
+++ b/src/pages/components/card-group.mdx
@@ -4,12 +4,10 @@ description: The Card group component is a collection of Card components that ca
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Card group component is a collection of Card components that can be used in block and group-level patterns.
-
-</PageDescription>
+<ComponentDescription name="Card Group" type="ui" />
 
 <AnchorLinks>
 

--- a/src/pages/components/card-link.mdx
+++ b/src/pages/components/card-link.mdx
@@ -4,12 +4,10 @@ description: The Card link is a card that acts as a CTA (call-to-action), typica
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Card link is a card that acts as a CTA (call-to-action), typically used at the end of a section of a page.
-
-</PageDescription>
+<ComponentDescription name="Card Link" type="ui" />
 
 <AnchorLinks>
 
@@ -42,4 +40,4 @@ The design specs and functional specs for Card link can be viewed <a href="https
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/card-section-carousel.mdx
+++ b/src/pages/components/card-section-carousel.mdx
@@ -4,12 +4,10 @@ description: Card section – carousel is a collection of cards presented within
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Card section – carousel is a collection of cards presented within a carousel related to a given topic for users to explore.
-
-</PageDescription>
+<ComponentDescription name="Card section - carousel" type="layout" />
 
 <AnchorLinks>
 
@@ -96,4 +94,4 @@ The design specs and functional specs for Card section – carousel can be viewe
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/card-section-images.mdx
+++ b/src/pages/components/card-section-images.mdx
@@ -4,12 +4,10 @@ description: Card section — with images is a collection of card components wit
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Card section — with images is a collection of card components with images that, together, occupy a full-width section with a left-column header. It is typically used for presenting resources or links.
-
-</PageDescription>
+<ComponentDescription name="Card section - with images" type="ui" />
 
 <AnchorLinks>
   
@@ -29,5 +27,5 @@ The design specs and functional specs for the Card section - with images can be 
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />
 

--- a/src/pages/components/card-section.mdx
+++ b/src/pages/components/card-section.mdx
@@ -4,12 +4,10 @@ description: Card section is a collection of cards presented in a full-width sec
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Card section is a collection of cards presented in a full-width section with a left-column header that responds to the grid. When using a CTA (call-to-action) within a card, use an icon. The Primary and Secondary buttons should be reserved for the most important action a user can take on the page.
-
-</PageDescription>
+<ComponentDescription name="Card section" type="layout" />
 
 <AnchorLinks>
 
@@ -43,4 +41,4 @@ The design specs and functional specs for Card section &mdash; simple can be vie
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/card.mdx
+++ b/src/pages/components/card.mdx
@@ -4,12 +4,10 @@ description: Component guideline page for Card.
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Card is a clickable UI item that is used to present content in a concise and readable way.
-
-</PageDescription>
+<ComponentDescription name="Card" type="ui" />
 
 <AnchorLinks>
 
@@ -57,4 +55,4 @@ The design specs and functional specs for Card can be viewed <a href="https://ib
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/carousel.mdx
+++ b/src/pages/components/carousel.mdx
@@ -4,12 +4,10 @@ description: Carousel is a flexible component that allows users to explore a lar
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Carousel is a flexible component that allows users to explore a large amount of content within a limited viewing area.
-
-</PageDescription>
+<ComponentDescription name="Carousel" type="ui" />
 
 <AnchorLinks>
   
@@ -29,5 +27,5 @@ The design specs and functional specs for the Carousel can be viewed <a href="ht
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />
 

--- a/src/pages/components/content-block-media.mdx
+++ b/src/pages/components/content-block-media.mdx
@@ -4,12 +4,10 @@ description: Content block &mdash; with media is used to present information wit
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Content block &mdash; with media is used to present information with images in a group setting.
-
-</PageDescription>
+<ComponentDescription name="Content block - with media" type="layout" />
 
 <AnchorLinks>
 
@@ -44,4 +42,4 @@ The design specs and functional specs for Content block &mdash; with media can b
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/content-block-segmented.mdx
+++ b/src/pages/components/content-block-segmented.mdx
@@ -4,12 +4,10 @@ description: Content block – segmented is used for introducing page content, s
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Content block – segmented is used for introducing page content, similar to Content block – simple but it has added ability to include subsections.
-
-</PageDescription>
+<ComponentDescription name="Content block - segmented" type="layout" />
 
 <AnchorLinks>
 
@@ -44,4 +42,4 @@ The design specs and functional specs for Content block &mdash; segmented can be
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/content-block-simple.mdx
+++ b/src/pages/components/content-block-simple.mdx
@@ -4,12 +4,10 @@ description: Content block &mdash; simple is typically used for the introductory
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Content block &mdash; simple is typically used for the introductory section on a page.
-
-</PageDescription>
+<ComponentDescription name="Content block - simple" type="layout" />
 
 <AnchorLinks>
 
@@ -45,4 +43,4 @@ The design specs and functional specs for Content block &mdash; simple can be vi
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/content-block-with-cards.mdx
+++ b/src/pages/components/content-block-with-cards.mdx
@@ -4,12 +4,10 @@ description: Content block &mdash; with cards is used to present small self-cont
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Content block &mdash; with cards is used to present small self-contained pieces of information as cards. Use this when the cards are part of the main narrative, as opposed to secondary links or resources.
-
-</PageDescription>
+<ComponentDescription name="Content block - with cards" type="layout" />
 
 <AnchorLinks>
 
@@ -49,4 +47,4 @@ The design specs and functional specs for Content block &mdash; with cards can b
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/content-group-horizontal.mdx
+++ b/src/pages/components/content-group-horizontal.mdx
@@ -4,12 +4,10 @@ description: Content group — horizontal can be used to present important areas
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Content group — horizontal can be used to present important areas of interest relating to your topic, such as products or solutions. 
-
-</PageDescription>
+<ComponentDescription name="Content group - horizontal" type="layout" />
 
 <AnchorLinks>
 

--- a/src/pages/components/content-group-pictograms.mdx
+++ b/src/pages/components/content-group-pictograms.mdx
@@ -4,12 +4,10 @@ description: Content group &mdash; with pictograms is to present a group of info
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Content group &mdash; with pictograms is to present a group of information, each with a supporting pictogram.
-
-</PageDescription>
+<ComponentDescription name="Content group - with pictograms" type="layout" />
 
 <AnchorLinks>
 
@@ -35,4 +33,4 @@ The design specs and functional specs for Content group &mdash; with pictograms 
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/content-group-simple.mdx
+++ b/src/pages/components/content-group-simple.mdx
@@ -4,12 +4,10 @@ description: Content group &mdash; simple is an alternative form of a narrative 
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Content group &mdash; simple is an alternative form of a narrative pattern where the content is broken up into smaller pieces to make it more digestible.
-
-</PageDescription>
+<ComponentDescription name="Content group - simple" type="layout" />
 
 <AnchorLinks>
 
@@ -35,5 +33,5 @@ The design specs and functional specs for Content group &mdash; simple can be vi
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />
 

--- a/src/pages/components/content-group-with-cards.mdx
+++ b/src/pages/components/content-group-with-cards.mdx
@@ -4,14 +4,10 @@ description: Content group &mdash; with cards is used to present information thr
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Content group &mdash; with cards is used to present information through a group of cards with each acting as a call to action that drives to additional or supporting destinations.
-
-It is suitable for adding concise buckets of content and links to a long-form reading experience.
-
-</PageDescription>
+<ComponentDescription name="Content group - with cards" type="layout" />
 
 <AnchorLinks>
 
@@ -37,4 +33,4 @@ The design specs and functional specs for Content group &mdash; with card can be
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/content-item-horizontal.mdx
+++ b/src/pages/components/content-item-horizontal.mdx
@@ -4,12 +4,10 @@ description: The Content item horizontal component displays information in a hor
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Content item horizontal component displays information in a horizontal orientation.
-
-</PageDescription>
+<ComponentDescription name="Content item horizontal" type="layout" />
 
 <AnchorLinks>
 
@@ -29,4 +27,4 @@ The design specs and functional specs for Content item horizontal can be viewed 
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/cta-section.mdx
+++ b/src/pages/components/cta-section.mdx
@@ -4,12 +4,10 @@ description: CTA (call-to-action) section is used to communicate actions that us
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-CTA (call-to-action) section is used to communicate actions that users can take at key points in your narrative, such as at the bottom of an important section or page where the user is ready to progress to subsequent stages in the journey. 
-
-</PageDescription>
+<ComponentDescription name="CTA section" type="layout" />
 
 <AnchorLinks>
 

--- a/src/pages/components/cta.mdx
+++ b/src/pages/components/cta.mdx
@@ -4,12 +4,10 @@ description: CTA stands for the call to action. A CTA refers to the use of words
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-CTA stands for the call to action. A CTA refers to the use of words or phrases that can compel an audience to act in a specific way.
-
-</PageDescription>
+<ComponentDescription name="CTA" type="ui" />
 
 <AnchorLinks>
   
@@ -29,4 +27,4 @@ The design specs and functional specs for the CTA can be viewed <a href="https:/
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/dotcom-shell.mdx
+++ b/src/pages/components/dotcom-shell.mdx
@@ -4,12 +4,10 @@ description: The Dotcom shell component includes the Masthead, and Footer compon
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Dotcom shell component includes the [Masthead](./../masthead), and [Footer](./../footer) components, all wrapped in a UI shell using Carbon’s grid.
-
-</PageDescription>
+<ComponentDescription name="Dotcom Shell" type="ui" />
 
 <AnchorLinks>
 

--- a/src/pages/components/expressive-modal.mdx
+++ b/src/pages/components/expressive-modal.mdx
@@ -4,12 +4,10 @@ description: The Expressive modal uses the Carbon modal and only deviates to inc
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Expressive modal uses the <a href="https://www.carbondesignsystem.com/components/modal/usage/" target="_blank">Carbon modal</a> and only deviates to increase readability and usability within expressive moments.
-
-</PageDescription>
+<ComponentDescription name="Expressive Modal" type="ui" />
 
 <AnchorLinks>
 
@@ -62,4 +60,4 @@ The design specs and functional specs for Expressive modal can be viewed <a href
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/feature-card-block.mdx
+++ b/src/pages/components/feature-card-block.mdx
@@ -4,12 +4,10 @@ description: Feature card block is used to present information with a group of c
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Feature card &mdash; block is used to present information with a group of cards.
-
-</PageDescription>
+<ComponentDescription name="Feature card - block medium" type="layout" />
 
 <AnchorLinks>
 
@@ -47,4 +45,4 @@ The design specs and functional specs for Feature card block &mdash; medium can 
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/feature-card.mdx
+++ b/src/pages/components/feature-card.mdx
@@ -4,12 +4,10 @@ description: The Feature card is used to emphasize a piece of information, indic
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Feature card is used to emphasize a piece of information, indicate significant progression or highlight an important next step.
-
-</PageDescription>
+<ComponentDescription name="Feature card" type="layout" />
 
 <AnchorLinks>
 
@@ -42,4 +40,4 @@ The design specs and functional specs for Feature card can be viewed <a href="ht
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/footer.mdx
+++ b/src/pages/components/footer.mdx
@@ -4,14 +4,10 @@ description: The Footer component page
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Footer is a section that sits at the bottom of any IBM.com page, and acts as the catch&mdash;all section that helps users navigate and provides corporate level general and legal information. The Footer is required on all pages on IBM.com.
-
-There are two different Footers. All pages are required to use the default Footer, with the exception of a few pages that need to minimize distraction, such as checkout process. Please [contact us](https://cognitive-app.slack.com/archives/C2PLX8GQ6) if you think your page needs approval to use the minimal Footer. 
-
-</PageDescription>
+<ComponentDescription name="Footer" type="ui" />
 
 <AnchorLinks>
 

--- a/src/pages/components/horizontal-rule.mdx
+++ b/src/pages/components/horizontal-rule.mdx
@@ -4,12 +4,10 @@ description: The Horizontal rule can be used as a graphical element to add struc
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Horizontal rule can be used as a graphical element to add structure, introduce breaks in the content, or delineate pieces of information.
-
-</PageDescription>
+<ComponentDescription name="Horizontal Rule" type="ui" />
 
 <AnchorLinks>
 
@@ -78,4 +76,4 @@ The design specs and functional specs for Horizontal rule can be viewed <a href=
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/image-with-caption.mdx
+++ b/src/pages/components/image-with-caption.mdx
@@ -4,12 +4,10 @@ description: The Image with caption is used to embed images and has an optional 
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Image with caption is used to embed images and has an optional caption. 
-
-</PageDescription>
+<ComponentDescription name="Image with caption" type="ui" />
 
 <AnchorLinks>
 
@@ -42,4 +40,4 @@ The design specs and functional specs for Image with caption can be viewed <a hr
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/image.mdx
+++ b/src/pages/components/image.mdx
@@ -4,12 +4,10 @@ description: The Image component is used as the primary way of embedding images 
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Image component is used as the primary way of embedding images on pages.
-
-</PageDescription>
+<ComponentDescription name="Image" type="ui" />
 
 <AnchorLinks>
 
@@ -24,4 +22,4 @@ The Image component is used as the primary way of embedding images on pages.
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/layout.mdx
+++ b/src/pages/components/layout.mdx
@@ -4,12 +4,10 @@ description: The Layout component is to be utilized within IBM.com for various a
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Layout component is to be utilized within IBM.com for various abstract layout configurations.
-
-</PageDescription>
+<ComponentDescription name="Layout" type="ui" />
 
 <AnchorLinks>
 
@@ -24,4 +22,4 @@ The Layout component is to be utilized within IBM.com for various abstract layou
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/lead-space-block.mdx
+++ b/src/pages/components/lead-space-block.mdx
@@ -4,14 +4,10 @@ description: Lead space &mdash; block is an alternative to the Lead space, enabl
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Lead space &mdash; block is an alternative to the [Lead space](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/patterns/leadspace), enabling a more productive first site of viewer engagement. 
-
-The Lead space &mdash; block is positioned at the top of a web page, with a purpose to orient the user when they land on a page, inform them of the content, and guide them to the first key piece of content on the page, whether it’s a crucial piece of information or a call-to-action button.
-
-</PageDescription>
+<ComponentDescription name="Lead space - block" type="layout" />
 
 <AnchorLinks>
 
@@ -39,4 +35,4 @@ The design specs and functional specs for Lead space &mdash; block can be viewed
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/leadspace.mdx
+++ b/src/pages/components/leadspace.mdx
@@ -4,14 +4,10 @@ description: A Lead space is positioned at the top of a web page and serves as t
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-A Lead space is positioned at the top of a web page and serves as the first site of user engagement. Its primary purpose is to orient the user when they land on a page, inform them of the content, and guide them to the first key piece of content on the page, whether it's a crucial piece of information or a call-to-action.
-
-For detailed guidelines around the general lead space pattern, please see the [Lead space pattern page](/patterns/lead-space).
-
-</PageDescription>
+<ComponentDescription name="Lead space" type="layout" />
 
 <AnchorLinks>
 
@@ -193,4 +189,4 @@ For further developer guidance view the LeadSpace README.md [here](https://githu
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/leaving-ibm.mdx
+++ b/src/pages/components/leaving-ibm.mdx
@@ -4,12 +4,10 @@ description: The Leaving IBM notice displays as an overlay when a user clicks an
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Leaving IBM notice displays as an overlay when a user clicks an external link.
-
-</PageDescription>
+<ComponentDescription name="Leaving IBM" type="ui" />
 
 <AnchorLinks>
 
@@ -24,5 +22,5 @@ The Leaving IBM notice displays as an overlay when a user clicks an external lin
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />
 

--- a/src/pages/components/lightbox-media-viewer.mdx
+++ b/src/pages/components/lightbox-media-viewer.mdx
@@ -4,12 +4,10 @@ description: The Lightbox media viewer allows the user to view an image or video
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Lightbox media viewer allows the user to view an image or video at a larger size within a modal.
-
-</PageDescription>
+<ComponentDescription name="Lightbox Media Viewer" type="ui" />
 
 <AnchorLinks>
 
@@ -53,4 +51,4 @@ The design specs and functional specs for Lightbox media viewer can be viewed <a
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/link-list.mdx
+++ b/src/pages/components/link-list.mdx
@@ -4,12 +4,10 @@ description: The Link list component is used to present links as a group.
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Link list is used to present links as a group.
-
-</PageDescription>
+<ComponentDescription name="Link List" type="ui" />
 
 <AnchorLinks>
 
@@ -97,4 +95,4 @@ The design specs and functional specs for Link list can be viewed <a href="https
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/link-with-icon.mdx
+++ b/src/pages/components/link-with-icon.mdx
@@ -4,12 +4,10 @@ description: The Link with icon is primarily used as a navigational element with
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Link with icon is primarily used as a navigational element with an icon as an indicator to the destination or type of content being referenced. 
-
-</PageDescription>
+<ComponentDescription name="Link with icon" type="ui" />
 
 <AnchorLinks>
 
@@ -46,4 +44,4 @@ The design specs and functional specs for Link with icon can be viewed <a href="
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/localemodal.mdx
+++ b/src/pages/components/localemodal.mdx
@@ -4,12 +4,10 @@ description: The Locale modal allows users to change geographic regions and lang
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Locale modal allows users to change geographic regions and languages. 
-
-</PageDescription>
+<ComponentDescription name="Locale Modal" type="ui" />
 
 <AnchorLinks>
 
@@ -36,4 +34,4 @@ The design specs and functional specs for the Locale modal can be viewed <a href
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/logo-grid.mdx
+++ b/src/pages/components/logo-grid.mdx
@@ -4,12 +4,10 @@ description: Logo grid is used to present a group of client or partner logos. Th
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-Logo grid is used to present a group of client or partner logos. This pattern is commonly used to establish credibility of the given product or service. 
-
-</PageDescription>
+<ComponentDescription name="Logo grid" type="layout" />
 
 <AnchorLinks>
 

--- a/src/pages/components/masthead.mdx
+++ b/src/pages/components/masthead.mdx
@@ -4,14 +4,10 @@ description: The Masthead component page
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Masthead is a fundamental and required navigational component for IBM.com that displays consistently at the top of each page. Masthead refers to all the standard navigation above the lead space. 
-
-There are two different variations of the Masthead, Masthead with Level 0 (L0) and Masthead with Level 1 (L1), which one is used depends on the page type. 
-
-</PageDescription>
+<ComponentDescription name="Masthead" type="ui" />
 
 <AnchorLinks>
 

--- a/src/pages/components/pictogram-item.mdx
+++ b/src/pages/components/pictogram-item.mdx
@@ -4,12 +4,10 @@ description: The Pictogram item is used to communicate messages at a glance, aff
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Pictogram item is used to communicate messages at a glance, afford interactivity, and simplify complex ideas.
-
-</PageDescription>
+<ComponentDescription name="Pictogram Item" type="ui" />
 
 <AnchorLinks>
 
@@ -24,4 +22,4 @@ The Pictogram item is used to communicate messages at a glance, afford interacti
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/quote.mdx
+++ b/src/pages/components/quote.mdx
@@ -4,12 +4,10 @@ description: The Quote component is used to highlight an impactful client statem
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Quote component is used to highlight an impactful client statement or user testimonial.
-
-</PageDescription>
+<ComponentDescription name="Quote" type="ui" />
 
 <AnchorLinks>
   
@@ -30,4 +28,4 @@ The design specs and functional specs for Quote can be viewed <a href="https://i
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+

--- a/src/pages/components/table-of-contents.mdx
+++ b/src/pages/components/table-of-contents.mdx
@@ -4,12 +4,10 @@ description: The Table of contents allows users to quickly navigate through long
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Table of contents allows users to quickly navigate through long pages by providing jump links to different sections of the content within a single page.
-
-</PageDescription>
+<ComponentDescription name="Table of contents" type="ui" />
 
 <AnchorLinks>
 
@@ -63,4 +61,4 @@ The design specs and functional specs for Table of contents can be viewed <a hre
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />

--- a/src/pages/components/video-player.mdx
+++ b/src/pages/components/video-player.mdx
@@ -4,12 +4,10 @@ description: The Video player uses Kaltura video platform and is the standard wa
 ---
 
 import { ComponentStatus } from 'components/ComponentList';
+import ComponentDescription from 'components/ComponentDescription';
+import ComponentFeedback from 'components/ComponentFeedback';
 
-<PageDescription>
-
-The Video player uses Kaltura video platform and is the standard way of using a video on pages and in components.
-
-</PageDescription>
+<ComponentDescription name="Video player" type="ui" />
 
 <AnchorLinks>
 
@@ -42,4 +40,4 @@ The design specs and functional specs for Video player can be viewed <a href="ht
 
 ## Feedback
 
-Help us improve this component by providing feedback, asking questions, and leaving any other comments on <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom" target="_blank">GitHub</a>.
+<ComponentFeedback />


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This feature adds the `ComponentDescription` and `ComponentFeedback` components, where the former is pulled from the `components.json` data file, and the latter is a centralized component for the feedback text for all component pages.

### Changelog

**New**

- `ComponentDescription`
- `ComponentFeedback`

**Changed**

- Updated `last updated` date in `Footer`