### PR TITLE
fix(homepage): fix to the homepage callout padding after gatsby update

### DIFF
--- a/src/gatsby-theme-carbon/components/Footer.js
+++ b/src/gatsby-theme-carbon/components/Footer.js
@@ -21,7 +21,7 @@ const CustomFooter = () => {
         .
       </p>
       <p>
-        Last updated February 5th, 2021
+        Last updated February 24th, 2021
         <br />
         Copyright &copy; 2021 IBM
       </p>

--- a/src/gatsby-theme-carbon/templates/Homepage.js
+++ b/src/gatsby-theme-carbon/templates/Homepage.js
@@ -90,7 +90,7 @@ const customProps = {
     </>
   ),
   FirstCallout: (
-    <div className={`bx--grid ${grid} ${firstCallout}`}>
+    <div className={`bx--grid homepage--callout ${grid} ${firstCallout}`}>
       <Row className={row}>
         <Column className={callout} colLg={7} colMd={5}>
           <h3>Get Started</h3>
@@ -114,7 +114,7 @@ const customProps = {
     </div>
   ),
   SecondCallout: (
-    <div className={`bx--grid ${grid}`}>
+    <div className={`bx--grid homepage--callout ${grid}`}>
       <Row className={row}>
         <Column className={callout} colLg={8} colMd={7}>
           <h3>Contribute</h3>

--- a/src/styles/_homepage.scss
+++ b/src/styles/_homepage.scss
@@ -11,6 +11,12 @@
   }
 
   .bx--grid {
+    padding-top: 3rem;
+
+    &.homepage--callout {
+      padding-top: 0;
+    }
+
     @include carbon--breakpoint("lg") {
       padding-left: calc(25% + 1.5rem);
     }


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This is a minor padding fix after the `gatsby-theme-carbon` was updated to the latest version. This fix is on the homepage for the `other resources` section.

### Changelog

**Changed**

- Homepage callout padding fixes
