### PR TITLE
fix(component-specs): swap out with design & func sharing links

### DIFF
--- a/src/pages/components/back-to-top.mdx
+++ b/src/pages/components/back-to-top.mdx
@@ -3,9 +3,9 @@ title: Back to top
 description: asdf.
 ---
 
-import { ComponentStatus } from 'components/ComponentList';
-import ComponentDescription from 'components/ComponentDescription';
-import ComponentFeedback from 'components/ComponentFeedback';
+import { ComponentStatus } from "components/ComponentList";
+import ComponentDescription from "components/ComponentDescription";
+import ComponentFeedback from "components/ComponentFeedback";
 
 <ComponentDescription name="Back to top" type="ui" />
 
@@ -20,7 +20,7 @@ import ComponentFeedback from 'components/ComponentFeedback';
 
 ## Default
 
-Back to top lives in the bottom right of the page, and only appears if the page is long enough as users are scrolling down the page. Once it reaches the footer it becomes static and scrolls with the rest of the content on the page until users scroll up again. 
+Back to top lives in the bottom right of the page, and only appears if the page is long enough as users are scrolling down the page. Once it reaches the footer it becomes static and scrolls with the rest of the content on the page until users scroll up again.
 
 <Row>
 <Column colMd={8} colLg={8}>
@@ -30,7 +30,6 @@ Back to top lives in the bottom right of the page, and only appears if the page 
 </Column>
 </Row>
 
-
 <Title>Use case</Title>
 
 ![Default Back to top component](../../images/component/back-to-top/back-to-top-sticky.jpg)
@@ -38,7 +37,8 @@ Back to top lives in the bottom right of the page, and only appears if the page 
 ![Default Back to top component](../../images/component/back-to-top/back-to-top-static.jpg)
 
 ## Design and functional specifications
-The design specs and functional specs for Back to top can be viewed <a href="https://ibm.ent.box.com/folder/127553793291" target="_blank" rel="noreferrer">here</a>.
+
+The design specs and functional specs for Back to top can be viewed <a href="https://ibm.box.com/s/1ol1qe0tdplhet6mh9z2sx5ncqmikd4r" target="_blank" rel="noreferrer">here</a>.
 
 ## Development documentation
 
@@ -47,4 +47,3 @@ The design specs and functional specs for Back to top can be viewed <a href="htt
 ## Feedback
 
 <ComponentFeedback />
-

--- a/src/pages/components/content-block-media.mdx
+++ b/src/pages/components/content-block-media.mdx
@@ -35,7 +35,7 @@ This variant is the same as the default version except that it allows for a list
 
 ## Design and functional specifications
 
-The design specs and functional specs for Content block &mdash; with media can be viewed <a href="https://ibm.ent.box.com/folder/94760926421" target="_blank">here</a>.
+The design specs and functional specs for Content block &mdash; with media can be viewed <a href="https://ibm.box.com/s/9cu22l7vs1dpjy8g8yi3mtoswazqgq2r" target="_blank">here</a>.
 
 ## Development documentation
 

--- a/src/pages/components/content-block-with-cards.mdx
+++ b/src/pages/components/content-block-with-cards.mdx
@@ -41,7 +41,7 @@ Sometimes a video will support the pages' narrative, but should not be prominent
 
 ## Design and functional specifications
 
-The design specs and functional specs for Content block &mdash; with cards can be viewed <a href="https://ibm.ent.box.com/folder/111084561933" target="_blank">here</a>.
+The design specs and functional specs for Content block &mdash; with cards can be viewed <a href="https://ibm.box.com/s/9pweudf9ptucx8jxzgo3e2m5jpyke5qi" target="_blank">here</a>.
 
 ## Development documentation
 

--- a/src/pages/components/expressive-modal.mdx
+++ b/src/pages/components/expressive-modal.mdx
@@ -55,7 +55,7 @@ The expanded variation fills the screen and is typically used to display large a
 
 ## Design and functional specifications
 
-The design specs and functional specs for Expressive modal can be viewed <a href="https://ibm.ent.box.com/folder/94774053664" target="_blank">here</a>.
+The design specs and functional specs for Expressive modal can be viewed <a href="https://ibm.box.com/s/35er5s6qfjcpcm98jafklc1alcl5vy16" target="_blank">here</a>.
 
 ## Development documentation
 

--- a/src/pages/components/leaving-ibm.mdx
+++ b/src/pages/components/leaving-ibm.mdx
@@ -3,9 +3,9 @@ title: Leaving IBM
 description: The Leaving IBM displays as an overlay when users click an external link.
 ---
 
-import { ComponentStatus } from 'components/ComponentList';
-import ComponentDescription from 'components/ComponentDescription';
-import ComponentFeedback from 'components/ComponentFeedback';
+import { ComponentStatus } from "components/ComponentList";
+import ComponentDescription from "components/ComponentDescription";
+import ComponentFeedback from "components/ComponentFeedback";
 
 <ComponentDescription name="Leaving IBM" type="ui" />
 
@@ -31,7 +31,8 @@ When a use clicks on an external link it will launch the Leaving IBM overlay to 
 </Row>
 
 ## Design and functional specifications
-The design specs and functional specs for Back to top can be viewed <a href="https://ibm.ent.box.com/folder/124606259113" target="_blank" rel="noreferrer">here</a>.
+
+The design specs and functional specs for Back to top can be viewed <a href="https://ibm.box.com/s/g79wdwdj0syjcfkdlgu5rpwe3zp9s37w" target="_blank" rel="noreferrer">here</a>.
 
 ## Development documentation
 
@@ -40,4 +41,3 @@ The design specs and functional specs for Back to top can be viewed <a href="htt
 ## Feedback
 
 <ComponentFeedback />
-


### PR DESCRIPTION
### Related Ticket(s)

[Dev Fix] Design and Function spec links are not accessible to adopters #877

### Description

Swap out root box folder links with the sharing links

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- {{removed thing}}
