### PR TITLE
fix(tables): ensured pages don't overflow on mobile

### DIFF
--- a/src/components/ComponentList/component-list.scss
+++ b/src/components/ComponentList/component-list.scss
@@ -1,3 +1,7 @@
+.component-list {
+  overflow-x: scroll;
+}
+
 .component-list .bx--tag {
   white-space: nowrap;
 }


### PR DESCRIPTION
### Related Ticket(s)
#697 

### Description
The Components page included an HTML table which overflowed on mobile, leading to empty space on the right upon scroll. This PR addresses it by adding `overflow-x: scroll` to `component-list` CSS class in order to only allow horizontal scrolling within the table itself, and not the page.

https://user-images.githubusercontent.com/24970122/113371329-eaa44900-931a-11eb-84e4-624f5b6d147f.mov



### Changelog

**New**

- added `overflow-x: scroll` to `component-list` CSS class applied to tables
