### PR TITLE
fix(left-menu): removed max height for open menu section

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -66,3 +66,7 @@ td > code {
     overflow-x: initial;
   }
 }
+
+.bx--side-nav__submenu[aria-expanded="true"] + .bx--side-nav__menu {
+  max-height: none;
+}


### PR DESCRIPTION
### Description

I've set the max-height for the opened menu item to none, in order to prevent items not being shown as the list grows.