### PR TITLE
fix(expressive-theme): adding back working link

### DIFF
--- a/src/pages/developing/index.mdx
+++ b/src/pages/developing/index.mdx
@@ -3,6 +3,8 @@ title: Developing
 description: Rapidly build beautiful and accessible experiences. Carbon for IBM.com contains all the resources you need to get started.
 ---
 
+import { Link } from 'gatsby';
+
 <PageDescription>
 
 Rapidly build beautiful and accessible experiences. Carbon for IBM.com contains all the resources you need to get started.
@@ -11,7 +13,7 @@ Rapidly build beautiful and accessible experiences. Carbon for IBM.com contains 
 
 <InlineNotification>
 
-**Note:** The Expressive Theme has been integrated into Carbon Design System’s core library. This means that expressive continues to be available to IBM.com, but now all Carbon adopters can get both productive and expressive experiences from the same library source. This change will be seamless for current users of Carbon for IBM.com. In the next few sprints, we will be shifting to use expressive styling and elements from core, after which the Expressive Theme within Carbon for IBM.com will no longer be maintained.
+**Note:** The Expressive Theme has been integrated into Carbon Design System’s core library. This means that expressive continues to be available to IBM.com, but now all Carbon adopters can get both productive and expressive experiences from the same library source. This change will be seamless for current users of Carbon for IBM.com. In the next few sprints, we will be shifting to use expressive styling and elements from core, after which the Expressive Theme within Carbon for IBM.com will no longer be maintained. <Link to="/help/expressive-update">Learn more about this change</Link>
 
 </InlineNotification>
 

--- a/src/pages/developing/index.mdx
+++ b/src/pages/developing/index.mdx
@@ -13,7 +13,7 @@ Rapidly build beautiful and accessible experiences. Carbon for IBM.com contains 
 
 <InlineNotification>
 
-**Note:** The Expressive Theme has been integrated into Carbon Design System’s core library. This means that expressive continues to be available to IBM.com, but now all Carbon adopters can get both productive and expressive experiences from the same library source. This change will be seamless for current users of Carbon for IBM.com. In the next few sprints, we will be shifting to use expressive styling and elements from core, after which the Expressive Theme within Carbon for IBM.com will no longer be maintained. <Link to="/help/expressive-update">Learn more about this change</Link>
+**Note:** The expressive theme has been integrated into Carbon Design System’s core library. This means that expressive continues to be available to IBM.com, but now all Carbon adopters can get both productive and expressive experiences from the same library source. This change will be seamless for current users of Carbon for IBM.com. In the next few sprints, we will be shifting to use expressive styling and elements from core, after which the expressive theme within Carbon for IBM.com will no longer be maintained. <Link to="/help/expressive-update">Learn more about this change</Link>.
 
 </InlineNotification>
 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This adds back in the link for the expressive theme notification, which will set the path correctly based on the path prefix defined in the project.

### Changelog

**Changed**

- expressive-theme.mdx
