### PR TITLE
docs(developing): adding framework documentation for developing section

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -9,7 +9,12 @@
     - path: /designing
 - title: Developing
   pages:
-    - path: /developing
+    - title: Get Started
+      path: /developing
+    - title: Frameworks
+      path: /developing/frameworks/web-components
+    - title: Other Packages
+      path: /developing/other-packages
 
 - title: Contributing
   pages:

--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -9,7 +9,7 @@
     - path: /designing
 - title: Developing
   pages:
-    - title: Get Started
+    - title: Get started
       path: /developing
     - title: Frameworks
       path: /developing/frameworks/web-components

--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -13,7 +13,7 @@
       path: /developing
     - title: Frameworks
       path: /developing/frameworks/web-components
-    - title: Other Packages
+    - title: Other packages
       path: /developing/other-packages
 
 - title: Contributing

--- a/src/pages/developing/frameworks/react.mdx
+++ b/src/pages/developing/frameworks/react.mdx
@@ -14,10 +14,10 @@ One of the most popular front-end frameworks today, React is the main framework 
 
 <AnchorLinks>
 <AnchorLink>Install</AnchorLink>
-<AnchorLink>Getting Started</AnchorLink>
-<AnchorLink>IBM.com Shell</AnchorLink>
-<AnchorLink>NextJS Template</AnchorLink>
-<AnchorLink>Available Components</AnchorLink>
+<AnchorLink>Getting started</AnchorLink>
+<AnchorLink>IBM.com shell</AnchorLink>
+<AnchorLink>NextJS template</AnchorLink>
+<AnchorLink>Available components</AnchorLink>
 <AnchorLink>Using with Carbon React</AnchorLink>
 </AnchorLinks>
 
@@ -35,7 +35,7 @@ Using [Yarn](https://yarnpkg.com/en/):
 yarn add @carbon/ibmdotcom-react
 ```
 
-## Getting Started
+## Getting started
 
 1. These components require the use of [Webpack](https://webpack.js.org/) in
    your project. See our
@@ -51,21 +51,21 @@ Styles are in a separate package entirely, as they are considered to be
 framework agnostic and can be used with any framework.
 [Learn how to include styles here](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles/README.md).
 
-## IBM.com Shell
+## IBM.com shell
 
-If you are looking to get started on a page, you can make use of the `<DotcomShell>`, which is a UI Shell that
+If you are looking to get started on a page, you can make use of the `<DotcomShell>`, which is a UI shell that
 contains the `<Masthead>` and the `<Footer>`, using Carbon's grid.
 
 View the `<DotcomShell>` in [Storybook React](https://ibmdotcom-react.mybluemix.net/?path=/story/components-dotcom-shell--default).
 
-## NextJS Template
+## NextJS template
 
 If you are looking to build out a light static site, the
 [NextJS template](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-nextjs-template) is available (using the
 React version of the Carbon for IBM.com). This includes the default configurations for the `<DotcomShell>`, as well as
 some sample components to get you started.
 
-## Available Components
+## Available components
 
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>

--- a/src/pages/developing/frameworks/react.mdx
+++ b/src/pages/developing/frameworks/react.mdx
@@ -1,0 +1,87 @@
+---
+title: Frameworks
+description: Carbon for IBM.com React
+tabs: ['Web Components','React']
+---
+
+import { Link } from 'gatsby';
+
+<PageDescription>
+
+One of the most popular front-end frameworks today, React is the main framework that is also supported by the core Carbon Design System team.
+
+</PageDescription>
+
+<AnchorLinks>
+<AnchorLink>Install</AnchorLink>
+<AnchorLink>Getting Started</AnchorLink>
+<AnchorLink>IBM.com Shell</AnchorLink>
+<AnchorLink>NextJS Template</AnchorLink>
+<AnchorLink>Available Components</AnchorLink>
+<AnchorLink>Using with Carbon React</AnchorLink>
+</AnchorLinks>
+
+## Install
+
+Using [npm](https://www.npmjs.com/):
+
+```bash
+npm i @carbon/ibmdotcom-react
+```
+
+Using [Yarn](https://yarnpkg.com/en/):
+
+```bash
+yarn add @carbon/ibmdotcom-react
+```
+
+## Getting Started
+
+1. These components require the use of [Webpack](https://webpack.js.org/) in
+   your project. See our
+   [`webpack.config.js`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/react/.storybook/webpack.config.js)
+   for an example configuration.
+
+2. Components do not import any of the styles themselves, use the scss or css
+   from `@carbon/ibmdotcom-styles` to bring in styling.
+
+### Styles
+
+Styles are in a separate package entirely, as they are considered to be
+framework agnostic and can be used with any framework.
+[Learn how to include styles here](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles/README.md).
+
+## IBM.com Shell
+
+If you are looking to get started on a page, you can make use of the `<DotcomShell>`, which is a UI Shell that
+contains the `<Masthead>` and the `<Footer>`, using Carbon's grid.
+
+View the `<DotcomShell>` in [Storybook React](https://ibmdotcom-react.mybluemix.net/?path=/story/components-dotcom-shell--default).
+
+## NextJS Template
+
+If you are looking to build out a light static site, the
+[NextJS template](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-nextjs-template) is available (using the
+React version of the Carbon for IBM.com). This includes the default configurations for the `<DotcomShell>`, as well as
+some sample components to get you started.
+
+## Available Components
+
+<Row className="resource-card-group">
+<Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="Carbon for IBM.com Storybook React"
+  href="https://ibmdotcom-react.mybluemix.net/"
+>
+
+![Storybook React](./../../../images/icon/react-icon.svg)
+
+</ResourceCard>
+</Column>
+
+</Row>
+
+## Using with Carbon React
+
+Carbon for IBM.com React uses the Carbon React library (`carbon-components-react`) under the hood. When building your 
+IBM.com application, both libraries can be used together. [Learn more about Carbon React](<a href="https://carbondesignsystem.com/developing/frameworks/react/">). 

--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -16,9 +16,9 @@ standard with native support, supported in all modern browsers.
 <AnchorLinks>
 <AnchorLink>Install (via import)</AnchorLink>
 <AnchorLink>Install (via CDN)</AnchorLink>
-<AnchorLink>IBM.com Shell</AnchorLink>
-<AnchorLink>Available Components</AnchorLink>
-<AnchorLink>React Wrapper</AnchorLink>
+<AnchorLink>IBM.com shell</AnchorLink>
+<AnchorLink>Available components</AnchorLink>
+<AnchorLink>React wrapper</AnchorLink>
 <AnchorLink>Using with Carbon Web Components</AnchorLink>
 </AnchorLinks>
 
@@ -87,14 +87,14 @@ without the need for front-end bundling:
 
 </InlineNotification> 
 
-## IBM.com Shell
+## IBM.com shell
 
-If you are looking to get started on a page, you can make use of the `<dds-dotcom-shell>`, which is a UI Shell that
+If you are looking to get started on a page, you can make use of the `<dds-dotcom-shell>`, which is a UI shell that
 contains the `<dds-masthead>` and the `<dds-footer>`, using Carbon's grid.
 
 View the `<dds-dotcom-shell>` in [Storybook Web Components](http://ibmdotcom-web-components.mybluemix.net/?path=/story/components-dotcom-shell--default).
 
-## Available Components
+## Available components
 
 <Row className="resource-card-group">
 
@@ -110,7 +110,7 @@ View the `<dds-dotcom-shell>` in [Storybook Web Components](http://ibmdotcom-web
 </Column>
 </Row>
 
-## React Wrapper
+## React wrapper
 
 Our team builds new components for Carbon for IBM.com as web components first. Anything that currently does not exist 
 in the <Link to="/developing/frameworks/react">React</Link> framework, are provided as web components with a React 

--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -1,0 +1,137 @@
+---
+title: Frameworks
+description: Carbon for IBM.com Web Components, using Custom Elements v1 and Shadow DOM v1 specs.
+tabs: ['Web Components','React']
+---
+
+import { Link } from 'gatsby';
+
+<PageDescription>
+
+Carbon for IBM.com Web Components uses the Custom Elements v1 and Shadow DOM v1 specs. Web components is the new browser 
+standard with native support, supported in all modern browsers. 
+
+</PageDescription>
+
+<AnchorLinks>
+<AnchorLink>Install (via import)</AnchorLink>
+<AnchorLink>Install (via CDN)</AnchorLink>
+<AnchorLink>IBM.com Shell</AnchorLink>
+<AnchorLink>Available Components</AnchorLink>
+<AnchorLink>React Wrapper</AnchorLink>
+<AnchorLink>Using with Carbon Web Components</AnchorLink>
+</AnchorLinks>
+
+## Install (via import)
+
+Using [npm](https://www.npmjs.com/):
+
+```bash
+npm install -S @carbon/ibmdotcom-web-components lit-html lit-element
+```
+
+Using [Yarn](https://yarnpkg.com/en/):
+
+```bash
+yarn add @carbon/ibmdotcom-web-components lit-html lit-element
+```
+
+### lit-html / lit-element
+
+`@carbon/ibmdotcom-web-components` uses [`lit-html`](https://lit-html.polymer-project.org) for reactive templating on 
+top of the Web Components standard, and [`lit-element`](https://lit-element.polymer-project.org) for reactive 
+properties/attributes on top of `lit-html`. These are `peerDependencies` of the project, so they would need to be 
+installed separately.
+
+## Install (via CDN)
+
+The IBM.com Shell is available via CDN, where a script tag can be added directly to an HTML page and rendered directly
+without the need for front-end bundling:
+ 
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module">
+      import 'https://1.www.s81c.com/common/carbon-for-ibm-dotcom/latest/ibmdotcom-web-components-dotcom-shell.min.js';
+
+      // The minimum prerequisite to properly set the current language/locale on the page
+      window.digitalData = {
+        page: {
+          pageInfo: {
+            language: 'en-US',
+            ibm: {
+              country: 'US',
+              siteID: 'IBMTESTWWW',
+            },
+          },
+          isDataLayerReady: true,
+        },
+      };
+    </script>
+
+    <!-- The minimum prerequisite to configure available language/locale combinations in the locale selector -->
+    <link rel="alternate" hreflang="en-us" href="https://www.ibm.com/us-en/" />
+    <link rel="alternate" hreflang="x-default" href="https://www.ibm.com" />
+    ...
+  </head>
+  <body>
+    <dds-dotcom-shell-container></dds-dotcom-shell-container>
+  </body>
+</html>
+```
+
+<InlineNotification>
+
+**Note:** Starting in Carbon for IBM.com Web Components v1.6.0, CDN artifacts will be available for all components! More details coming soon!
+
+</InlineNotification> 
+
+## IBM.com Shell
+
+If you are looking to get started on a page, you can make use of the `<dds-dotcom-shell>`, which is a UI Shell that
+contains the `<dds-masthead>` and the `<dds-footer>`, using Carbon's grid.
+
+View the `<dds-dotcom-shell>` in [Storybook Web Components](http://ibmdotcom-web-components.mybluemix.net/?path=/story/components-dotcom-shell--default).
+
+## Available Components
+
+<Row className="resource-card-group">
+
+<Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="Carbon for IBM.com Storybook Web Components"
+  href="https://ibmdotcom-web-components.mybluemix.net/"
+>
+
+![Storybook Web Components](./../../../images/icon/js_logo.svg)
+
+</ResourceCard>
+</Column>
+</Row>
+
+## React Wrapper
+
+Our team builds new components for Carbon for IBM.com as web components first. Anything that currently does not exist 
+in the <Link to="/developing/frameworks/react">React</Link> framework, are provided as web components with a React 
+wrapper for seamless integration into a React application.
+
+<Row className="resource-card-group">
+
+<Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="Carbon for IBM.com Storybook Web Components with React"
+  href="https://ibmdotcom-web-components-react.mybluemix.net/"
+>
+
+![Storybook React](./../../../images/icon/react-icon.svg)
+
+</ResourceCard>
+</Column>
+</Row>
+
+## Using with Carbon Web Components
+
+Carbon for IBM.com Web Components uses the Carbon Web Components library (`carbon-web-components`) under the hood. 
+When building your IBM.com application, both libraries can be used together. Carbon Web Components is the web component 
+version of core Carbon Design System. [Learn more about Carbon Web Components](https://carbondesignsystem.com/developing/frameworks/web-components).

--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -22,7 +22,7 @@ standard with native support, supported in all modern browsers.
 <AnchorLink>Using with Carbon Web Components</AnchorLink>
 </AnchorLinks>
 
-## Install (via import)
+## Install via import
 
 Using [npm](https://www.npmjs.com/):
 
@@ -43,7 +43,7 @@ top of the Web Components standard, and [`lit-element`](https://lit-element.poly
 properties/attributes on top of `lit-html`. These are `peerDependencies` of the project, so they would need to be 
 installed separately.
 
-## Install (via CDN)
+## Install via CDN
 
 The IBM.com Shell is available via CDN, where a script tag can be added directly to an HTML page and rendered directly
 without the need for front-end bundling:

--- a/src/pages/developing/index.mdx
+++ b/src/pages/developing/index.mdx
@@ -7,111 +7,70 @@ import { Link } from 'gatsby';
 
 <PageDescription>
 
-Rapidly build beautiful and accessible experiences. Carbon for IBM.com contains all the resources you need to get started.
+Carbon for IBM.com provides front-end developers and engineers a collection of reusable components to build websites and
+user interfaces quickly and efficiently. Adopting the library enables developers to use consistent markup, styles, and
+behavior in prototype and production work.
 
 </PageDescription>
 
-<InlineNotification>
-
-**Note:** The expressive theme has been integrated into Carbon Design System’s core library. This means that expressive continues to be available to IBM.com, but now all Carbon adopters can get both productive and expressive experiences from the same library source. This change will be seamless for current users of Carbon for IBM.com. In the next few sprints, we will be shifting to use expressive styling and elements from core, after which the expressive theme within Carbon for IBM.com will no longer be maintained. <Link to="/help/expressive-update">Learn more about this change</Link>.
-
-</InlineNotification>
-
 <AnchorLinks>
-<AnchorLink>Carbon for IBM.com</AnchorLink>
-<AnchorLink>Get started</AnchorLink>
-<AnchorLink>Packages</AnchorLink>
+<AnchorLink>Choose Your Framework</AnchorLink>
+<AnchorLink>Building for IBM.com</AnchorLink>
 <AnchorLink>Accessibility</AnchorLink>
 <AnchorLink>Tutorials</AnchorLink>
 <AnchorLink>Contributing</AnchorLink>
 </AnchorLinks>
 
+## Choose your framework
 
-## Carbon for IBM.com
+Carbon for IBM.com is available in either <Link to="/developing/frameworks/web-components">web components</Link> or 
+<Link to="/developing/frameworks/react">react</Link>. Choosing a framework would depend on the needs of 
+your application. 
 
-Carbon for IBM.com provides front-end developers and engineers a collection of reusable components to build websites and
-user interfaces quickly and efficiently. Adopting the library enables developers to use consistent markup, styles, and
-behavior in prototype and production work.
+### Web Components
 
-## Get Started
+Web components is the new browser standard with native support, supported in all modern browsers. This uses the Custom 
+Elements v1 and Shadow DOM v1 specs. Adding web components to your application is as simple as adding custom HTML markup 
+to your pages! Web components also comes with performance benefits of less scripting cost on page render compared to 
+using current framework solutions. More importantly, web components can be used in tandem with any framework(s) included
+on the page. 
 
-### Building for IBM.com
+Web components are also fully rendered in Google search crawlers (which currently holds the largest market share for 
+search engines), with light support in other crawlers like Bing and Yahoo. 
+
+If you're running an Angular, Vue, or vanilla application, our team recommends using web components. Web components 
+would also work in React applications. Our team provides <Link to="/developing/frameworks/web-components#react-wrapper">React wrapper</Link> 
+versions of Carbon for IBM.com Web Components. 
+
+<p>
+<Link to="/developing/frameworks/web-components">Get started with Carbon for IBM.com Web Components</Link>
+</p>
+
+### React 
+
+React is also supported by our team. One of the most popular front-end frameworks today, it is the front-end framework 
+that is also supported by the core Carbon Design System team. If your application runs on React, our team recommends 
+Carbon for IBM.com React. 
+
+<p>
+<Link to="/developing/frameworks/react">Get started with Carbon for IBM.com React</Link>
+</p>  
+
+## Building for IBM.com
 
 All pages on IBM.com must follow various standards and configurations, regardless of framework chosen. To read more,
 visit [Building for IBM.com](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/building-for-ibm-dotcom.md).
 
-### IBM.com Shell
-
-If you are looking to get started on a page, you can make use of the `<DotcomShell>`, which is a UI Shell that
-contains the `<Masthead>` and the `<Footer>`, using Carbon's grid. 
-
-View the React version at [Storybook React](https://ibmdotcom-react.mybluemix.net/?path=/story/components-dotcom-shell--default).
-
-View the Web Components version at [Storybook Web Components](http://ibmdotcom-web-components.mybluemix.net/?path=/story/components-dotcom-shell--default).
-
-### NextJS Template
-
-If you are looking to build out a light static site, the
-[NextJS template](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-nextjs-template) is available (using the
-React version of the Carbon for IBM.com). This includes the default configurations for the `<DotcomShell>`, as well as
-some sample components to get you started.
-
-### Available Components
-
-<Row className="resource-card-group">
-<Column colMd={4} colLg={4} noGutterSm>
-<ResourceCard
-  subTitle="Carbon for IBM.com Storybook React"
-  href="https://ibmdotcom-react.mybluemix.net/"
->
-
-![Storybook React](./../../images/icon/react-icon.svg)
-
-</ResourceCard>
-</Column>
-
-<Column colMd={4} colLg={4} noGutterSm>
-<ResourceCard
-  subTitle="Carbon for IBM.com Storybook Web Components"
-  href="https://ibmdotcom-web-components.mybluemix.net/"
->
-
-![Storybook Web Components](./../../images/icon/js_logo.svg)
-
-</ResourceCard>
-</Column>
-</Row>
-
-### Expressive Theme
-
-The expressive theme for Carbon components is available in our [Styles package](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles).
-
-[Click here to learn more about the expressive theme.](/guidelines/expressive-theme)
-
-
-## Packages
-
-Carbon for IBM.com comes with a variety of packages. While the main package used would be either [React](https://ibmdotcom-react.mybluemix.net)
-or [Web Components](https://ibmdotcom-web-components.mybluemix.net), there are also separate packages that can be
-utilized as their own standalone functionality.
-
-| Package name                                                                                                                                                  | Description                                                                 | Dependencies Included                                                                                                                                                                                                       |
-| ------------------------------------------------------------------------------------------------------------------------------------                          | --------------------------------------------------------------------------- | ----------------------------------------------------------------                                                                                                                                                            |
-| **React**<br/>([`@carbon/ibmdotcom-react`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/react))                            | IBM.com React components and patterns                                       | &ndash;&nbsp;&nbsp;Latest Carbon<br/>&ndash;&nbsp;&nbsp;Services<br/>&ndash;&nbsp;&nbsp;Utilities<br/><br/><em>NOTE: Styles will need to be included separately</em> |
-| **Web Components**<br/>([`@carbon/ibmdotcom-web-components`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/web-components)) | IBM.com Web Components - components and patterns using the new web standard | &ndash;&nbsp;&nbsp;Latest Carbon<br/>&ndash;&nbsp;&nbsp;Styles<br/>&ndash;&nbsp;&nbsp;Services<br/>&ndash;&nbsp;&nbsp;Utilities                     |
-| **Styles**<br/>([`@carbon/ibmdotcom-styles`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles))                         | Framework agnostic styles package for IBM.com components                    | &ndash;&nbsp;&nbsp;Latest Carbon                                                                                                                                                                          |
-| **Services**<br/>([`@carbon/ibmdotcom-services`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/services))                   | IBM.com ES6 Service classes                                                 | &ndash;&nbsp;&nbsp;Utilities                                                                                                                                                                              |
-| **Utilities**<br/>([`@carbon/ibmdotcom-utilities`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/utilities))                | IBM.com ES6 Utility classes                                                 |                                                                                                                                                                                                                             |
-
-To find additional development resources, visit our [Resource page](/resources).
-
 ## Accessibility
 
-Accessible design not only helps users with disabilities; it provides better user experiences for everyone. Please view the <a href="https://www.carbondesignsystem.com/guidelines/accessibility/overview" target="_blank">Accessibility guideline</a> on the Carbon website to learn more about the accessibility best practices.
+Accessible design not only helps users with disabilities; it provides better user experiences for everyone. 
+Please view the <a href="https://www.carbondesignsystem.com/guidelines/accessibility/overview" target="_blank">Accessibility guideline</a> 
+on the Carbon website to learn more about the accessibility best practices.
 
 ## Tutorials
 
-To help you get started with Carbon for IBM.com, [watch the replays from the Digital Design Summit](https://ec.yourlearning.ibm.com/w3/series/10148614?layout=grid) to learn about the React and Web component libraries, and how to contribute to Carbon for IBM.com.
+To help you get started with Carbon for IBM.com, [watch the replays from the Digital Design Summit](https://ec.yourlearning.ibm.com/w3/series/10148614?layout=grid) 
+to learn about the React and Web component libraries, and how to contribute to Carbon for IBM.com.
 
 ## Contributing
 

--- a/src/pages/developing/index.mdx
+++ b/src/pages/developing/index.mdx
@@ -16,7 +16,7 @@ behavior in prototype and production work.
 </PageDescription>
 
 <AnchorLinks>
-<AnchorLink>Choose Your Framework</AnchorLink>
+<AnchorLink>Choose your framework</AnchorLink>
 <AnchorLink>Building for IBM.com</AnchorLink>
 <AnchorLink>Accessibility</AnchorLink>
 <AnchorLink>Tutorials</AnchorLink>

--- a/src/pages/developing/index.mdx
+++ b/src/pages/developing/index.mdx
@@ -29,7 +29,7 @@ Carbon for IBM.com is available in either <Link to="/developing/frameworks/web-c
 <Link to="/developing/frameworks/react">react</Link>. Choosing a framework would depend on the needs of 
 your application. 
 
-### Web Components
+### Web components
 
 Web components is the new browser standard with native support, supported in all modern browsers. This uses the Custom 
 Elements v1 and Shadow DOM v1 specs. Adding web components to your application is as simple as adding custom HTML markup 

--- a/src/pages/developing/other-packages/index.mdx
+++ b/src/pages/developing/other-packages/index.mdx
@@ -1,0 +1,119 @@
+---
+title: Other Packages
+description: In addition to the frameworks, Carbon for IBM.com comes with modular packages for styles, services, and utilities. 
+---
+
+import { Link } from 'gatsby';
+
+<PageDescription>
+
+In addition to the frameworks, Carbon for IBM.com comes with modular packages for styles, services, and utilities.
+
+</PageDescription>
+
+<AnchorLinks>
+<AnchorLink>Other Packages</AnchorLink>
+<AnchorLinks small>
+  <AnchorLink>Styles</AnchorLink>
+  <AnchorLink>Services & Utilities</AnchorLink>
+</AnchorLinks>
+</AnchorLinks>
+
+## Other Packages
+
+In addition to the framework packages (<Link to="/developing/frameworks/web-components">Web Components</Link> and <Link to="/developing/frameworks/react">React</Link>),
+there are other public packages available that are used within the framework packages, and could also be used as 
+isolated modular functionality and styling within an application.
+
+### Styles
+
+In order to share styles across the framework packages, styles have been separated into its own standalone package. The
+styles package also includes the <Link to="/guidelines/expressive-theme">expressive theme</Link>.
+
+<InlineNotification>
+
+**Note:** The expressive theme has been integrated into Carbon Design System’s core library. This means that expressive 
+continues to be available to IBM.com, but now all Carbon adopters can get both productive and expressive experiences 
+from the same library source. This change will be seamless for current users of Carbon for IBM.com. In the next few 
+sprints, we will be shifting to use expressive styling and elements from core, after which the expressive theme within 
+Carbon for IBM.com will no longer be maintained. <Link to="/help/expressive-update">Learn more about this change</Link>.
+
+</InlineNotification> 
+
+<Row className="resource-card-group">
+
+<Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="Carbon for IBM.com Styles"
+  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles"
+>
+
+![Github icon](./../../../images/icon/github-icon.svg)
+
+</ResourceCard>
+</Column>
+
+<Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="Carbon Expressive Theme"
+  href="https://carbon-expressive.mybluemix.net"
+>
+
+![React icon](./../../../images/icon/react-icon.svg)
+
+</ResourceCard>
+</Column>
+</Row>
+
+### Services & Utilities
+
+Carbon for IBM.com contains its own API and utility functionality that have been separated out into their own modular 
+packages. They are exported as pure ES6 classes.
+
+<Row className="resource-card-group">
+
+<Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="Carbon for IBM.com Services"
+  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/services"
+>
+
+![Github icon](./../../../images/icon/github-icon.svg)
+
+</ResourceCard>
+</Column>
+
+<Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="Services API Documentation"
+  href="https://ibmdotcom-services.mybluemix.net"
+>
+
+![JSDoc](./../../../images/icon/js_logo.svg)
+
+</ResourceCard>
+</Column>
+
+<Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="Carbon for IBM.com Utilities"
+  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/utilities"
+>
+
+![Github icon](./../../../images/icon/github-icon.svg)
+
+</ResourceCard>
+</Column>
+
+<Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="Utilities API Documentation"
+  href="https://ibmdotcom-utilities.mybluemix.net"
+>
+
+![JSDoc](./../../../images/icon/js_logo.svg)
+
+</ResourceCard>
+</Column>
+  
+</Row>

--- a/src/pages/developing/other-packages/index.mdx
+++ b/src/pages/developing/other-packages/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Other Packages
+title: Other packages
 description: In addition to the frameworks, Carbon for IBM.com comes with modular packages for styles, services, and utilities. 
 ---
 
@@ -12,14 +12,14 @@ In addition to the frameworks, Carbon for IBM.com comes with modular packages fo
 </PageDescription>
 
 <AnchorLinks>
-<AnchorLink>Other Packages</AnchorLink>
+<AnchorLink>Modular packages</AnchorLink>
 <AnchorLinks small>
   <AnchorLink>Styles</AnchorLink>
-  <AnchorLink>Services & Utilities</AnchorLink>
+  <AnchorLink>Services and utilities</AnchorLink>
 </AnchorLinks>
 </AnchorLinks>
 
-## Other Packages
+## Modular packages
 
 In addition to the framework packages (<Link to="/developing/frameworks/web-components">Web Components</Link> and <Link to="/developing/frameworks/react">React</Link>),
 there are other public packages available that are used within the framework packages, and could also be used as 
@@ -65,7 +65,7 @@ Carbon for IBM.com will no longer be maintained. <Link to="/help/expressive-upda
 </Column>
 </Row>
 
-### Services & Utilities
+### Services and utilities
 
 Carbon for IBM.com contains its own API and utility functionality that have been separated out into their own modular 
 packages. They are exported as pure ES6 classes.


### PR DESCRIPTION
### Related Ticket(s)

Refs #642 

### Description

This updates the `developing` section to include framework guidance, as well as updated general development documentation.

### Changelog

**New**

- Developing / Frameworks
- Other packages

**Changed**

- Developing landing page
