### PR TITLE
docs(web-components-template): coming soon documentation

### DIFF
--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -18,6 +18,7 @@ standard with native support, supported in all modern browsers.
 <AnchorLink>Install (via CDN)</AnchorLink>
 <AnchorLink>IBM.com shell</AnchorLink>
 <AnchorLink>Available components</AnchorLink>
+<AnchorLink>Carbon for IBM.com Web Components Template</AnchorLink>
 <AnchorLink>React wrapper</AnchorLink>
 <AnchorLink>Using with Carbon Web Components</AnchorLink>
 </AnchorLinks>
@@ -109,6 +110,10 @@ View the `<dds-dotcom-shell>` in [Storybook Web Components](http://www.ibm.com/s
 </ResourceCard>
 </Column>
 </Row>
+
+## Carbon for IBM.com Web Components Template
+
+Our team is currently developing a starter application using Carbon for IBM.com Web Components. More details coming soon! 
 
 ## React wrapper
 

--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -18,7 +18,7 @@ standard with native support, supported in all modern browsers.
 <AnchorLink>Install (via CDN)</AnchorLink>
 <AnchorLink>IBM.com shell</AnchorLink>
 <AnchorLink>Available components</AnchorLink>
-<AnchorLink>Carbon for IBM.com Web Components template</AnchorLink>
+<AnchorLink>Web components template</AnchorLink>
 <AnchorLink>React wrapper</AnchorLink>
 <AnchorLink>Using with Carbon Web Components</AnchorLink>
 </AnchorLinks>
@@ -111,7 +111,7 @@ View the `<dds-dotcom-shell>` in [Storybook Web Components](http://www.ibm.com/s
 </Column>
 </Row>
 
-## Carbon for IBM.com Web Components template
+## Web components template
 
 Our team is currently developing a starter application using Carbon for IBM.com Web Components. More details coming soon! 
 

--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -18,7 +18,7 @@ standard with native support, supported in all modern browsers.
 <AnchorLink>Install (via CDN)</AnchorLink>
 <AnchorLink>IBM.com shell</AnchorLink>
 <AnchorLink>Available components</AnchorLink>
-<AnchorLink>Carbon for IBM.com Web Components Template</AnchorLink>
+<AnchorLink>Carbon for IBM.com Web Components template</AnchorLink>
 <AnchorLink>React wrapper</AnchorLink>
 <AnchorLink>Using with Carbon Web Components</AnchorLink>
 </AnchorLinks>
@@ -111,7 +111,7 @@ View the `<dds-dotcom-shell>` in [Storybook Web Components](http://www.ibm.com/s
 </Column>
 </Row>
 
-## Carbon for IBM.com Web Components Template
+## Carbon for IBM.com Web Components template
 
 Our team is currently developing a starter application using Carbon for IBM.com Web Components. More details coming soon! 
 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This adds a quick message about the web components template coming soon. Hoping to be able to announce it in the coming sprints once engineering is able to fully review what we have so far.

### Changelog

**Changed**

- Added section for the web components template
