### PR TITLE
website: fix alpha order in left nav

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -44,10 +44,10 @@
       path: /guidelines/layout
     - title: Right-to-left language
       path: /guidelines/right-to-left
-    - title: Style models
-      path: /guidelines/style-models/overview
     - title: Spacing
       path: /guidelines/spacing
+    - title: Style models
+      path: /guidelines/style-models/overview
     - title: Type pairing
       path: /guidelines/type-pairing
 
@@ -151,12 +151,12 @@
       path: /components/quote
     - title: Table of contents
       path: /components/table-of-contents
-    - title: Tag link
-      path: /components/tag-link
     - title: Tabs extended
       path: /components/tabs-extended
     - title: Tabs extended media
       path: /components/tabs-extended-media
+    - title: Tag link
+      path: /components/tag-link
     - title: Video
       path: /components/video
 


### PR DESCRIPTION
Quick fix of a couple of items in the left nav that were not in alphabetical order. 