### PR TITLE
docs: footer component typo fixes

### DIFF
--- a/src/data/components.json
+++ b/src/data/components.json
@@ -301,7 +301,7 @@
     "Footer": {
       "url": "./footer",
       "designLink": "https://ibm.box.com/s/nsbccv6jigfw78uwq3r0242qks1x1f87",
-      "description": "The footer component is a section that sits at the bottom of any IBM.com page, and acts as the catch—all section that helps users navigate and provides corporate level general and legal information. The footer is required on all pages on IBM.com.",
+      "description": "The footer component is a section that sits at the bottom of any IBM.com page, and acts as the catch-all section that helps users navigate and provides corporate level general and legal information. The footer is required on all pages on IBM.com.",
       "storybook": {
         "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-footer--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-footer--default"

--- a/src/pages/components/footer.mdx
+++ b/src/pages/components/footer.mdx
@@ -13,7 +13,7 @@ import ComponentFooter from "components/ComponentFooter";
 <AnchorLink>Default</AnchorLink>
 <AnchorLink>Variations</AnchorLink>
 <AnchorLink>Anatomy</AnchorLink>
-<AnchorLink>Behaviour</AnchorLink>
+<AnchorLink>Behavior</AnchorLink>
 <AnchorLink>Design and functional specifications</AnchorLink>
 <AnchorLink>Development documentation</AnchorLink>
 <AnchorLink>Feedback</AnchorLink>
@@ -157,7 +157,7 @@ Do not use an adjunct legal link to write footnotes or content-related notices. 
   
 
 
-## Behaviour
+## Behavior
 
 
 ### Default


### PR DESCRIPTION
This PR replaces an incorrect en dash with a hyphen in the component description, and fixes a British English word with American English spelling.  