### PR TITLE
Docs  images resource link

### DIFF
--- a/src/data/components.json
+++ b/src/data/components.json
@@ -407,6 +407,33 @@
         "notAvailable": false
       }
     },
+    "Image with caption": {
+      "url": "./image-with-caption",
+      "designLink": "https://ibm.box.com/s/mclmewshqcme7g6gykepok78rm882a0j",
+      "description": "The Image with caption component is used to embed images and has an optional caption. It can support images at 1x1, 2x1, 4x3 and 16x9 aspect ratios.",
+      "storybook": {
+        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-image-with-caption--default",
+        "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-imagewithcaption--default"
+      },
+      "webcomponents": {
+        "stable": true,
+        "experimental": false,
+        "new": true,
+        "updated": false,
+        "deprecated": false,
+        "underConstruction": false,
+        "notAvailable": false
+      },
+      "react": {
+        "stable": true,
+        "experimental": false,
+        "new": false,
+        "updated": false,
+        "deprecated": false,
+        "underConstruction": false,
+        "notAvailable": false
+      }
+    },
     "Leaving IBM": {
       "url": "./leaving-ibm",
       "designLink": "https://ibm.box.com/s/g79wdwdj0syjcfkdlgu5rpwe3zp9s37w",

--- a/src/pages/components/images.mdx
+++ b/src/pages/components/images.mdx
@@ -74,34 +74,7 @@ Inside the overlay, the caption becomes the heading and there is an opportunity 
 </Row>
 <Caption>When an image has a caption, the user can hover over the image and click to trigger a Lightbox overlay with more information.</Caption>
 
-### Resources for Image with caption
-
-<CardGroup>
-  <MiniCard
-    title="Design specifications"
-    href="https://ibm.ent.box.com/folder/109643123498?s=mclmewshqcme7g6gykepok78rm882a0j"
-  >
-    <img src={sketchSymbol} alt="Sketch"/>
-  </MiniCard>
-  <MiniCard
-    title="Functional specifications"
-    href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Image-with-caption"
-  >
-    <img src={githubSymbol} alt="Github"/>
-  </MiniCard>
-  <MiniCard
-    title="React Storybook"
-    href="https://www.ibm.com/standards/carbon/react/?path=/story/components-image-with-caption--default"
-  >
-    <img src={reactSymbol} alt="React"/>
-  </MiniCard>
-  <MiniCard
-    title="Web Components Storybook"
-    href="https://www.ibm.com/standards/carbon/web-components/?path=/story/components-image-with-caption--default"
-  >
-    <img src={webComponentsSymbol} alt="Web Components"/>
-  </MiniCard>
-</CardGroup>
+<ResourceLinks name="Image with caption" type="ui" multiComponent/>
 
 ### Content guidance for Image with caption
 Image is a foundational component and does not contain any additional content. Image with caption provides the opportunity for additional content, as shown in the following table.

--- a/src/pages/components/images.mdx
+++ b/src/pages/components/images.mdx
@@ -29,7 +29,7 @@ There are two image components available. The Image component allows for a simpl
 
 Image, at its core, is a wrapper that adds an image to the page. You have the option to pass multiple images to the image component to render at the various breakpoints. This is particularly useful if you want to render different images at different screen sizes.
 
-We recommend displaying images at 1:1, 2:1, 4:3, and 16:9 aspect ratios. For guidance on choosing or creating imagery, see the IBM Design Language <a href="https://www.ibm.com/design/language/photography/overview" target="_blank">photography guidelines</a>. 
+We recommend displaying images at 1:1, 2:1, 4:3, and 16:9 aspect ratios. For guidance on choosing or creating imagery, see the IBM Design Language [photography guidelines](https://www.ibm.com/design/language/photography/overview).
 
 <Row>
 <Column colMd={8} colLg={8}>
@@ -61,7 +61,7 @@ The border feature is available for images with and without captions.
 
 ## Image with caption
 
-An image can include a caption beneath the image itself to provide more context. Using the Image with caption component, the image can be clicked to open an overlay (<a href="https://www.ibm.com/standards/carbon/components/lightbox-media-viewer" target="_blank">Lightbox media viewer</a>) that houses a larger version of the image.
+An image can include a caption beneath the image itself to provide more context. Using the Image with caption component, the image can be clicked to open an overlay ([Lightbox media viewer](https://www.ibm.com/standards/carbon/components/lightbox-media-viewer)) that houses a larger version of the image.
  
 Inside the overlay, the caption becomes the heading and there is an opportunity for additional body text.
 
@@ -85,6 +85,6 @@ Image is a foundational component and does not contain any additional content. I
 | Copy                                                                                                       | Text  | No       | 1           | 150 / 200                                                             | This is only shown in the lightbox media viewer (if enabled)                                                           |     |
 | Media                                 | Image  | Yes      | 1           | –                                              | –                                                                                                                                 |
 
-For more information, see the <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Character-count-standards" target="_blank" rel="noreferrer">character count standards</a>.
+For more information, see the [character count standards](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Character-count-standards).
 
 <ComponentFooter name="Image" type="ui" />

--- a/src/pages/components/tabs-extended.mdx
+++ b/src/pages/components/tabs-extended.mdx
@@ -80,26 +80,6 @@ On mobile, Tabs extended media renders as an accordion for easier browsing.
 </Column>
 </Row>
 
-### Resources for Tabs extended media
-<CardGroup>
-  <MiniCard
-    title="Design specifications"
-    href="https://ibm.ent.box.com/folder/133803243554"
-  >
-    <img src={sketchSymbol} alt="Sketch"/>
-  </MiniCard>
-  <MiniCard
-    title="Functional specifications"
-    href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Tabs-extended-media"
-  >
-    <img src={githubSymbol} alt="Github"/>
-  </MiniCard>
-  <MiniCard
-    title="Web components Storybook"
-    href="https://www.ibm.com/standards/carbon/web-components/?path=/story/components-tabs-extended-with-media--default"
-  >
-    <img src={webComponentsSymbol} alt="Web Components"/>
-  </MiniCard>
-</CardGroup>
+<ResourceLinks name="Tabs extended media" type="layout"  multiComponent/>
 
 <ComponentFooter name="Tabs extended" type="ui" />


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

Update to ResourceLinks for `Images` and `Tabs extended` to use the automated code instead of manual cards.

### Changelog

**New**

- N/A

**Changed**

- Images page updated - `Image with caption` ResourceLink
- Tabs extended updated - `Tabs extended media` ResourceLink
- Re-added Image with caption to json file

**Removed**

- N/A
