### PR TITLE
Update "release schedule" card to link to issue 5888

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -80,7 +80,7 @@ building websites and user interfaces. See a
     actionIcon="launch"
     aspectRatio="1:1"
     target="_blank"
-    href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues"
+    href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5888"
     >
 
 ![Calendar Pictogram](../images/icon/calendar.svg)


### PR DESCRIPTION
### Related Ticket(s)

No ticket 

### Description

Noticed that the card on homepage for "Release schedule" only points to Github/issues, which is not helpful. Added the current specific release schedule issue. If Roberta stops updating that issue, we will make a PR to follow up. 