### PR TITLE
fix(dev-pages): fix to properly build the auto generated dev pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -18,29 +18,28 @@ async function _createBuildForIBMPage() {
   const buildForIBMheading = `${dest}/heading.txt`;
   const buildForIBMdest = `${dest}/index.mdx`;
 
-  // Download the `Building for IBM.com` docs page from the Carbon for IBM.com repo
-  await fetch(buildForIBMsrc, {
-    method: "get",
-    headers: {
-      "Content-Type": "text/html",
-    },
-  })
-    .then((response) => response.text())
-    .then((response) => {
-      const heading = fs.readFileSync(buildForIBMheading);
-      const final = response.substring(
-        response.indexOf("prettier-ignore-end") + 23,
-        response.length - 1
-      );
-      if (
-        fs.readFileSync(buildForIBMdest).toString() !== `${heading}${final}`
-      ) {
-        fs.writeFileSync(buildForIBMdest, `${heading}${final}`);
-      }
+  if(!fs.existsSync(buildForIBMdest)) {
+    // Download the `Building for IBM.com` docs page from the Carbon for IBM.com repo
+    await fetch(buildForIBMsrc, {
+      method: "get",
+      headers: {
+        "Content-Type": "text/html",
+      },
     })
-    .catch((err) => {
-      console.error(err);
-    });
+      .then((response) => response.text())
+      .then((response) => {
+        const heading = fs.readFileSync(buildForIBMheading);
+        const final = response.substring(
+          response.indexOf("prettier-ignore-end") + 23,
+          response.length - 1
+        );
+
+        fs.writeFileSync(buildForIBMdest, `${heading}${final}`);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
 }
 
 /**
@@ -59,29 +58,28 @@ async function _createCDNStyleHelpersPage() {
   const styleHelpersheading = `${dest}/heading.txt`;
   const styleHelpersdest = `${dest}/index.mdx`;
 
-  // Download the `Building for IBM.com` docs page from the Carbon for IBM.com repo
-  await fetch(styleHelperssrc, {
-    method: "get",
-    headers: {
-      "Content-Type": "text/html",
-    },
-  })
-    .then((response) => response.text())
-    .then((response) => {
-      const heading = fs.readFileSync(styleHelpersheading);
-      const final = response.substring(
-        response.indexOf("prettier-ignore-end") + 23,
-        response.length - 1
-      );
-      if (
-        fs.readFileSync(styleHelpersdest).toString() !== `${heading}${final}`
-      ) {
-        fs.writeFileSync(styleHelpersdest, `${heading}${final}`);
-      }
+  if(!fs.existsSync(styleHelpersdest)) {
+    // Download the `Building for IBM.com` docs page from the Carbon for IBM.com repo
+    await fetch(styleHelperssrc, {
+      method: "get",
+      headers: {
+        "Content-Type": "text/html",
+      },
     })
-    .catch((err) => {
-      console.error(err);
-    });
+      .then((response) => response.text())
+      .then((response) => {
+        const heading = fs.readFileSync(styleHelpersheading);
+        const final = response.substring(
+          response.indexOf("prettier-ignore-end") + 23,
+          response.length - 1
+        );
+
+        fs.writeFileSync(styleHelpersdest, `${heading}${final}`);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
 }
 
 exports.createPages = async () => {

--- a/package.json
+++ b/package.json
@@ -3,20 +3,21 @@
   "version": "1.0.0",
   "license": "Apache-2.0",
   "scripts": {
+    "clean": "gatsby clean",
+    "clean:dev-pages": "rimraf src/pages/developing/building-for-ibm-dotcom/index.mdx src/pages/developing/carbon-cdn-style-helpers/index.mdx",
+    "build": "gatsby build --prefix-paths",
+    "build:analyze": "ANALYZE=true yarn build",
+    "build:clean": "yarn clean && gatsby build --prefix-paths",
+    "build:wiki": "node node_modules/wiki-helpers/index.js rootPath=./wiki buildPath=./wiki-build flattenDir=true",
     "dev": "gatsby develop -H 0.0.0.0",
     "dev:clean": "yarn clean && yarn dev",
-    "build": "gatsby build --prefix-paths",
-    "build:clean": "yarn clean && gatsby build --prefix-paths",
     "format": "prettier --write 'src/**/*.{css,scss,js,json,html,yaml,md,mdx}'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "postinstall": "husky install",
-    "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",
-    "serve": "gatsby serve",
-    "clean": "gatsby clean",
-    "build:analyze": "ANALYZE=true yarn build",
-    "build-wiki": "node node_modules/wiki-helpers/index.js rootPath=./wiki buildPath=./wiki-build flattenDir=true"
+    "prepublishOnly": "pinst --disable",
+    "serve": "gatsby serve"
   },
   "dependencies": {
     "@carbon/icons-react": "^10.27.0",


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The production build was failing as it was not properly building the auto-generated dev pages. The logic was changed so that it will only run if the page doesn't exist.

New node script `clean:dev-pages` was also added.

### Changelog

**Changed**

- Changed logic for building dev pages

