### PR TITLE
Fix for Box links on Designing page

### DIFF
--- a/src/pages/designing/index.mdx
+++ b/src/pages/designing/index.mdx
@@ -82,7 +82,7 @@ If you’re brand new to Sketch, they offer some great [tutorials and documentat
 
 _For IBMers only_: We provide Sketch files of all the Carbon for IBM.com components, at the different breakpoints. These are available on Box.
 
-| Component types                 | Description                      |
+| Component types                 | Description                           |
 | ------------------------------- | ------------------------------------- |
 | [_Layout components_](https://ibm.box.com/s/67mx3puesjjz8lnosnrma8d45as3g33j)            | Layout components show some of the common layouts used in IBM’s digital space. They are carefully designed and coded to communicate prescribed content types and are expressions of IBM’s distinct brand ethos.      |
 | [_UI components_](https://ibm.box.com/s/yqwhif915fwn9avz8gytvkc1p1038ofo)             | UI components are designed and built to support or enable small UI tasks and actions. They can be paired with other components to create layout components, templates, and patterns.     |
@@ -242,7 +242,6 @@ Accessible design not only helps users with disabilities; it provides better use
 ## Tutorials
 
 To help you get started with Carbon for IBM.com, [watch the replays](https://ec.yourlearning.ibm.com/w3/series/10148614?layout=grid0) from the Digital Design Summit to learn about the foundation of Carbon for IBM.com, the design resources, and how to use the design system.
-
 
 ## Support
 If you experience any issues while getting set up with Carbon for IBM.com, go to our [GitHub repo](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-design-kit) and [create an issue](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-design-kit/issues/new?assignees=oliviaflory&template=bug-report.md&title=%5BDesign+kit%5D%3A+Brief+description) if your issue does not already exist. 

--- a/src/pages/designing/index.mdx
+++ b/src/pages/designing/index.mdx
@@ -84,10 +84,10 @@ _For IBMers only_: We provide Sketch files of all the Carbon for IBM.com compone
 
 | Component types                 | Description                      |
 | ------------------------------- | ------------------------------------- |
-| [_Layout components_]((https://ibm.box.com/s/67mx3puesjjz8lnosnrma8d45as3g33j))            | Layout components show some of the common layouts used in IBM’s digital space. They are carefully designed and coded to communicate prescribed content types and are expressions of IBM’s distinct brand ethos.      |
-| [_UI components_]((https://ibm.box.com/s/yqwhif915fwn9avz8gytvkc1p1038ofo))             | UI components are designed and built to support or enable small UI tasks and actions. They can be paired with other components to create layout components, templates, and patterns.     |
-| [_Design only_]((https://ibm.box.com/s/ixj9x7d1uis2eubqag3485cov7h2bsm1))              | These components have a design but are not yet available in code. If your team would like to build any of these components, please reach out to the Carbon for IBM.com team.             |
-| [_Feature flag_]((https://ibm.box.com/s/t4r3s0zsuo7ahbj0coi5yfy8ynzlgax0))   | These components are built under the feature flag branch and are being tested before adding to the library permanently. Use with caution as the Carbon for IBM.com team may sunset these components at any time. |
+| [_Layout components_](https://ibm.box.com/s/67mx3puesjjz8lnosnrma8d45as3g33j)            | Layout components show some of the common layouts used in IBM’s digital space. They are carefully designed and coded to communicate prescribed content types and are expressions of IBM’s distinct brand ethos.      |
+| [_UI components_](https://ibm.box.com/s/yqwhif915fwn9avz8gytvkc1p1038ofo)             | UI components are designed and built to support or enable small UI tasks and actions. They can be paired with other components to create layout components, templates, and patterns.     |
+| [_Design only_](https://ibm.box.com/s/ixj9x7d1uis2eubqag3485cov7h2bsm1)              | These components have a design but are not yet available in code. If your team would like to build any of these components, please reach out to the Carbon for IBM.com team.             |
+| [_Feature flag_](https://ibm.box.com/s/t4r3s0zsuo7ahbj0coi5yfy8ynzlgax0)   | These components are built under the feature flag branch and are being tested before adding to the library permanently. Use with caution as the Carbon for IBM.com team may sunset these components at any time. |
 
 You can also get to these component resources from the Design specifications card on the individual component pages.  
 


### PR DESCRIPTION
This PR addresses an issue on the `Designing` page. 

It removes double parentheses that were causing links to the Box folder to break. 

