### PR TITLE
website: Developing page, remove anchor links

### DIFF
--- a/src/pages/developing/other-packages/index.mdx
+++ b/src/pages/developing/other-packages/index.mdx
@@ -11,14 +11,6 @@ In addition to the frameworks, Carbon for IBM.com comes with modular packages fo
 
 </PageDescription>
 
-<AnchorLinks>
-<AnchorLink>Modular packages</AnchorLink>
-<AnchorLinks small>
-  <AnchorLink>Styles</AnchorLink>
-  <AnchorLink>Services and utilities</AnchorLink>
-</AnchorLinks>
-</AnchorLinks>
-
 ## Modular packages
 
 In addition to the framework packages (<Link to="/developing/frameworks/web-components">Web Components</Link> and <Link to="/developing/frameworks/react">React</Link>),


### PR DESCRIPTION
This PR removes the anchor links from the `Developing` > `Other packages` page. Only one H2 and in these cases, we don't need them.

Addresses #1206 from Mike Abbink.