### PR TITLE
Website: Remove design kit link from left nav

### DIFF
--- a/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
+++ b/src/gatsby-theme-carbon/components/LeftNav/ResourceLinks.js
@@ -10,10 +10,6 @@ const links = [
     title: "IBM.com Web Standards",
     href: "https://www.ibm.com/standards/web",
   },
-  {
-    title: "Design kit",
-    href: "/designing/#install-the-sketch-kit",
-  },
 ];
 
 // shouldOpenNewTabs: true if outbound links should open in a new tab


### PR DESCRIPTION
This PR removes the `Design kit` link from the left nav. 

This link goes to the middle of the Designing page, where the Sketch kits are sitting, which is a little odd. We are also working on multiple kits and have some alpha ones available. Better to remove the link entirely and create some air on the left nav. 