### PR TITLE
fix(ComponentGallery): import module defaults

### DIFF
--- a/src/components/ComponentGallery/ComponentGallery.js
+++ b/src/components/ComponentGallery/ComponentGallery.js
@@ -27,7 +27,7 @@ function getImage(component) {
     componentImg = require('./images/coming_soon.svg');
   }
 
-  return componentImg;
+  return componentImg.default;
 }
 
 /**


### PR DESCRIPTION
### Related Ticket(s)

#1338

related https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/pull/1226

### Description

This PR updates the ComponentGallery image imports so that thumbnails load correctly again. The breakage likely comes from webpack changes related to updating Gatsby, as they are showing up as modules rather than the SVG strings

![image](https://user-images.githubusercontent.com/8265238/140384121-3ffbeb59-b214-4c9d-913d-03020766da77.png)

![image](https://user-images.githubusercontent.com/8265238/140383834-4cf3363a-859f-47b9-8d05-5189d9c7985b.png)
