### PR TITLE
Sketch kit page H2 update

### DIFF
--- a/src/pages/designing/sketch-kit.mdx
+++ b/src/pages/designing/sketch-kit.mdx
@@ -144,7 +144,7 @@ individual component pages.
 
 ## Other Sketch resources
 
-**1. Bring in colors and icons**
+#### Bring in colors and icons
 
 Additional color collections live in the IBM Design Language library. Icons live
 in two different libraries separated by size.
@@ -190,7 +190,7 @@ in two different libraries separated by size.
 
 <br />
 
-**2. Download the grid template**
+#### Download the grid template
 
 Visit the
 [Sketch library](https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e)

--- a/src/pages/designing/sketch-kit.mdx
+++ b/src/pages/designing/sketch-kit.mdx
@@ -17,7 +17,7 @@ get started designing web pages for IBM.com.
 <AnchorLink>Install the new Sketch kit</AnchorLink>
 <AnchorLink>Get Carbon for IBM.com components</AnchorLink>
 <AnchorLink>Other Sketch resources</AnchorLink>
-<AnchorLink>Sketch tips</AnchorLink>
+<AnchorLink>Using the Sketch kit</AnchorLink>
 
 </AnchorLinks>
 
@@ -214,7 +214,7 @@ access the saved grid template at `File → New file from Template`.
 
 <br />
 
-## Sketch tips
+## Using the Sketch kit
 
 Our Sketch resources are set up to help you design using key IBM assets. Learn
 more about using the [2x Grid](designing#2x-grid), [Symbols](designing#symbols),


### PR DESCRIPTION
This PR updates the Sketch kit page H2 heading `Sketch tips` to `Using the Sketch kit`, which is more accurate and informative. And will now match Rich's proposal for Figma kit page! 🎉  