### PR TITLE
fix(beacon): changed endpoint to live beacon API url

### DIFF
--- a/src/components/BeaconWebUI/BeaconWebUI.js
+++ b/src/components/BeaconWebUI/BeaconWebUI.js
@@ -22,7 +22,7 @@ const BeaconWebUI = () => {
       const iframe = document.getElementById('beacon-web-ui-iframe');
       const url = document.getElementById('text-input-1').value;
       fetch(
-        `https://beacon-for-ibm-dotcom-api.herokuapp.com/?raw=true&url=${url}`
+        `https://beacon-for-ibm-dotcom-api.gz4o4xx2g28.us-south.codeengine.appdomain.cloud/?url=${url}`
       )
         .then((response) => response.text())
         .then((data) => {


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This adjusts the Beacon web UI page to point to the working endpoint on IBM Cloud.

NOTE: Url for testing is https://ibmdotcom-library.s3-web.us-south.cloud-object-storage.appdomain.cloud/deploy-previews/1366/resources/beacon/. 

@kennylam the endpoint needs to be adjusted to allow for CORS I believe, otherwise this might be good to go.

### Changelog

**Changed**

- Changed Beacon endpoint to `beacon-for-ibm-dotcom-api.gz4o4xx2g28.us-south.codeengine.appdomain.cloud`
