### PR TITLE
Update lead-space [Fix Broken Links].mdx

### DIFF
--- a/src/pages/patterns/lead-space.mdx
+++ b/src/pages/patterns/lead-space.mdx
@@ -249,11 +249,11 @@ Recommendation: Research has shown that there is a benefit to placing the primar
 
 <Title>Components</Title>
 
-- [Lead space left-aligned](/components/leadspace#lead-space-left-aligned)
-- [Lead space centered](/components/leadspace#lead-space-centered)
+- [Lead space left-aligned](https://www.ibm.com/standards/carbon/components/leadspace#variants)
+- [Lead space centered](https://www.ibm.com/standards/carbon/components/leadspace#centered)
 - [Lead space block](/components/lead-space-block)
 
 <Title>Patterns</Title>
 
-- [Call-to-action](../patterns/call-to-action)
+- [Call-to-action](https://www.ibm.com/standards/carbon/patterns/call-to-action)
 - [Cards](../patterns/cards)

--- a/src/pages/patterns/lead-space.mdx
+++ b/src/pages/patterns/lead-space.mdx
@@ -249,11 +249,11 @@ Recommendation: Research has shown that there is a benefit to placing the primar
 
 <Title>Components</Title>
 
-- [Lead space left-aligned](https://www.ibm.com/standards/carbon/components/leadspace#variants)
-- [Lead space centered](https://www.ibm.com/standards/carbon/components/leadspace#centered)
+- [Lead space left-aligned](/components/leadspace#variants)
+- [Lead space centered](/components/leadspace#centered)
 - [Lead space block](/components/lead-space-block)
 
 <Title>Patterns</Title>
 
-- [Call-to-action](https://www.ibm.com/standards/carbon/patterns/call-to-action)
+- [Call-to-action](../patterns/call-to-action)
 - [Cards](../patterns/cards)


### PR DESCRIPTION
This PR fixes 3 broken links in the Related Components and Patterns section of the lead space patterns page:

Lead space left-aligned
Lead space centered
Call-to-action