### PR TITLE
Update resources link for content item horizontal

### DIFF
--- a/src/data/components.json
+++ b/src/data/components.json
@@ -1195,7 +1195,7 @@
     },
     "Content item horizontal": {
       "url": "./content-item-horizontal",
-      "designLink": "https://ibm.box.com/s/911wx1w694l21iazjcw9powshyxmk0du",
+      "designLink": "https://ibm.box.com/s/yiv7f37ktudwx1do7d9mp4bak17wl4dh",
       "description": "Content item horizontal component displays information in a horizontal orientation.",
       "storybook": {
         "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-item-horizontal--default",


### PR DESCRIPTION
The content item horizontal Sketch file link is broken and stating "file not found". Updating the URL to fix it

### Related Ticket(s)

[Slack thread](https://cognitive-app.slack.com/archives/C2PLX8GQ6/p1638386953255500?thread_ts=1638383164.248800&cid=C2PLX8GQ6) for context

### Description

Fixing error message of file not found in Box
![Screen Shot 2021-12-01 at 3 01 13 PM](https://user-images.githubusercontent.com/45692622/144305310-dfe5fac1-3b1a-42e3-a4fb-4ad38da8a10a.png)


Updating the resources link for Sketch on the Content item horizontal page

![Screen Shot 2021-12-01 at 2 38 18 PM](https://user-images.githubusercontent.com/45692622/144305437-72f4731c-fb0d-4c49-bfba-5ce01d5a44a0.png)

### Changelog

**New**

- {{new thing}}

**Changed**

- New link to Box folder in the component.json file for the Resources

**Removed**

- old link to Box folder
