### PR TITLE
docs(tutorial): update to dotcom shell setup steps

### DIFF
--- a/src/pages/developing/web-components-tutorial/step-1.mdx
+++ b/src/pages/developing/web-components-tutorial/step-1.mdx
@@ -129,20 +129,18 @@ Your default browser should open up with an empty page that says:
 Even though we installed existing dependencies, we've yet to install the Carbon for IBM.com packages.
 
 - `@carbon/ibmdotcom-web-components` - web components
-- `lit-element` - peer dependency for rendering Carbon for IBM.com web components
-- `lit-html` - peer dependency for rendering Carbon for IBM.com web components
 
 Stop your development server with `CTRL-C` and install Carbon for IBM.com dependencies with:
 
 ```bash
-yarn add @carbon/ibmdotcom-web-components@1.9.0 lit-element@2.5.1 lit-html@1.4.1
+yarn add @carbon/ibmdotcom-web-components@1.14.0
 ```
 
 In addition to `Carbon for IBM.com` dependencies, additional Carbon packages will need to be included to build the
 overall experience:
 
 ```bash
-yarn add carbon-web-components@1.16.2 carbon-components@10.43.0 @carbon/type@10.35.0 @carbon/grid@10.35.0 @carbon/themes@10.42.0
+yarn add carbon-web-components@1.19.0 carbon-components@10.49.0 @carbon/type@10.38.0 @carbon/grid@10.39.0 @carbon/themes@10.47.0
 ```
 
 ## Install and build Sass

--- a/src/pages/developing/web-components-tutorial/step-1.mdx
+++ b/src/pages/developing/web-components-tutorial/step-1.mdx
@@ -226,14 +226,16 @@ with:
 <!-- prettier-ignore-start -->
 
 ```html path=src/index.html
-<dds-button-group>
-  <dds-button-group-item href="https://example.com">
-    Lorem ipsum
-  </dds-button-group-item>
-  <dds-button-group-item href="https://example.com">
-    Dolor sit amet
-  </dds-button-group-item>
-</dds-button-group>
+<body>
+  <dds-button-group>
+    <dds-button-group-item href="https://example.com">
+      Lorem ipsum
+    </dds-button-group-item>
+    <dds-button-group-item href="https://example.com">
+      Dolor sit amet
+    </dds-button-group-item>
+  </dds-button-group>
+</body>
 ```
 
 <!-- prettier-ignore-end -->
@@ -253,9 +255,11 @@ In the `index.html` page, replace the previously added `button-group` with the f
 <!-- prettier-ignore-start -->
 
 ```html path=src/index.html
-<dds-dotcom-shell-container>
-  <main>Hello World!</main>
-</dds-dotcom-shell-container>
+<body>
+  <dds-dotcom-shell-container>
+    <main>Hello World!</main>
+  </dds-dotcom-shell-container>
+</body>
 ```
 
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

There are some minor tweaks to the step 1 content for the tutorial. Bumped to latest versions of dependencies, and dropped `lit-html` and `lit-element` based on latest version requirements.

### Changelog

**Changed**

- Step 1 tutorial instructions
