### PR TITLE
chore(branch): replace references of `master` branch to `main`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -52,7 +52,7 @@ body:
       options:
         - label:
             I agree to follow this project's [Code of
-            conduct](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/blob/master/.github/CODE_OF_CONDUCT.md).
+            conduct](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/blob/main/.github/CODE_OF_CONDUCT.md).
           required: true
         - label:
             I checked the [current

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -39,7 +39,7 @@ body:
       options:
         - label:
             I agree to follow this project's [Code of
-            conduct](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/blob/master/.github/CODE_OF_CONDUCT.md).
+            conduct](https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/blob/main/.github/CODE_OF_CONDUCT.md).
           required: true
         - label:
             I checked the [current

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,7 +16,7 @@ async function createBuildForIBMPage() {
     'src/pages/developing/building-for-ibm-dotcom'
   );
   const buildForIBMsrc =
-    'https://raw.githubusercontent.com/carbon-design-system/carbon-for-ibm-dotcom/master/docs/building-for-ibm-dotcom.md';
+    'https://raw.githubusercontent.com/carbon-design-system/carbon-for-ibm-dotcom/main/docs/building-for-ibm-dotcom.md';
   const buildForIBMheading = `${dest}/heading.txt`;
   const buildForIBMdest = `${dest}/index.mdx`;
 
@@ -57,7 +57,7 @@ async function createCDNStyleHelpersPage() {
     'src/pages/developing/carbon-cdn-style-helpers'
   );
   const styleHelperssrc =
-    'https://raw.githubusercontent.com/carbon-design-system/carbon-for-ibm-dotcom/master/packages/web-components/docs/carbon-cdn-style-helpers.md';
+    'https://raw.githubusercontent.com/carbon-design-system/carbon-for-ibm-dotcom/main/packages/web-components/docs/carbon-cdn-style-helpers.md';
   const styleHelpersheading = `${dest}/heading.txt`;
   const styleHelpersdest = `${dest}/index.mdx`;
 

--- a/src/pages/contributing/components.mdx
+++ b/src/pages/contributing/components.mdx
@@ -328,7 +328,7 @@ For guidance, see our Documentation requirements section above or reach out to u
 
 #### 5. Working code
 
-The component for **Carbon for IBM.com** must be built in one of our supported frameworks - React or Web Components. We'd like to prioritize working on Web Components since it has become our strategic direction. If you need help learning how to build it in Web Components, reach out to the engineers in our slack channel for training <a href="https://ibm-studios.slack.com/archives/C2PLX8GQ6" target="_blank">#carbon-for-ibm-dotcom</a>. Please read the [Developer guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/developing.md) and the [Submissions guidelines](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/submission-guidelines.md) for more details.
+The component for **Carbon for IBM.com** must be built in one of our supported frameworks - React or Web Components. We'd like to prioritize working on Web Components since it has become our strategic direction. If you need help learning how to build it in Web Components, reach out to the engineers in our slack channel for training <a href="https://ibm-studios.slack.com/archives/C2PLX8GQ6" target="_blank">#carbon-for-ibm-dotcom</a>. Please read the [Developer guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/docs/developing.md) and the [Submissions guidelines](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/docs/submission-guidelines.md) for more details.
 
 ## Steps to contributing
 

--- a/src/pages/contributing/overview.mdx
+++ b/src/pages/contributing/overview.mdx
@@ -64,7 +64,7 @@ Maintainers are Carbon for IBM.com team members who are committed to the success
 
 ## Project workflow
 
-Carbon for IBM.com projects typically use a [fork and pull request workflow](https://guides.github.com/activities/forking/) for contributions. Specific instructions can be found in our [Contribution Guidelines](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/.github/CONTRIBUTING.md).
+Carbon for IBM.com projects typically use a [fork and pull request workflow](https://guides.github.com/activities/forking/) for contributions. Specific instructions can be found in our [Contribution Guidelines](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/.github/CONTRIBUTING.md).
 
 ## Contributor License Agreement
 

--- a/src/pages/developing/frameworks/react.mdx
+++ b/src/pages/developing/frameworks/react.mdx
@@ -39,7 +39,7 @@ yarn add @carbon/ibmdotcom-react
 
 1. These components require the use of [Webpack](https://webpack.js.org/) in
    your project. See our
-   [`webpack.config.js`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/react/.storybook/webpack.config.js)
+   [`webpack.config.js`](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/packages/react/.storybook/webpack.config.js)
    for an example configuration.
 
 2. Components do not import any of the styles themselves, use the scss or css
@@ -49,7 +49,7 @@ yarn add @carbon/ibmdotcom-react
 
 Styles are in a separate package entirely, as they are considered to be
 framework agnostic and can be used with any framework.
-[Learn how to include styles here](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/packages/styles/README.md).
+[Learn how to include styles here](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/packages/styles/README.md).
 
 ## IBM.com shell
 

--- a/src/pages/developing/index.mdx
+++ b/src/pages/developing/index.mdx
@@ -80,5 +80,5 @@ to learn about the React and Web component libraries, and how to contribute to C
 
 We're always looking for contributors to help us fix bugs, build new features, or help us improve the project
 documentation. If you're interested, definitely check out our
-[Contributing Guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/.github/CONTRIBUTING.md) and
-our [Developer Guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/developing.md)!
+[Contributing Guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/.github/CONTRIBUTING.md) and
+our [Developer Guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/docs/developing.md)!

--- a/src/pages/developing/other-packages/index.mdx
+++ b/src/pages/developing/other-packages/index.mdx
@@ -37,7 +37,7 @@ Carbon for IBM.com will no longer be maintained. <Link to="/help/expressive-upda
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Carbon for IBM.com Styles"
-  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles"
+  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/styles"
 >
 
 ![GitHub icon](./../../../images/icon/github-icon.svg)
@@ -67,7 +67,7 @@ packages. They are exported as pure ES6 classes.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Carbon for IBM.com Services"
-  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/services"
+  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/services"
 >
 
 ![GitHub icon](./../../../images/icon/github-icon.svg)
@@ -89,7 +89,7 @@ packages. They are exported as pure ES6 classes.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Carbon for IBM.com Utilities"
-  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/utilities"
+  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/utilities"
 >
 
 ![GitHub icon](./../../../images/icon/github-icon.svg)

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -100,7 +100,7 @@ IBM.com.
   <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Building for IBM.com"
-  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/master/docs/building-for-ibm-dotcom.md"
+  href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/docs/building-for-ibm-dotcom.md"
 >
 
 ![GitHub icon](./../../images/icon/github-icon.svg)

--- a/wiki/UI-component/Footer.md
+++ b/wiki/UI-component/Footer.md
@@ -41,7 +41,7 @@ _{{backlinks auto populates}}_
 
 - r1: [Box folder](https://ibm.ent.box.com/folder/101562989787)
 - r2:
-  [IBM logo](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/styles/icons/svg)
+  [IBM logo](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/styles/icons/svg)
 
 <br />
 </details>


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5230

### Description

This updates various references of the `master` branch to `main`.

### Changelog

**Changed**

- Multiple file changes for branch rename to `main`
