### PR TITLE
Contributing page topic order adjustment

### DIFF
--- a/src/pages/contributing/components.mdx
+++ b/src/pages/contributing/components.mdx
@@ -11,10 +11,23 @@ or a brand new component.
 </PageDescription>
 
 <AnchorLinks>
+  <AnchorLink>Steps to contributing</AnchorLink>
   <AnchorLink>How to write component guidance</AnchorLink>
   <AnchorLink>Parts of a component contribution</AnchorLink>
-  <AnchorLink>Steps to contributing</AnchorLink>
 </AnchorLinks>
+
+## Steps to contributing
+
+To contribute a component to Carbon for IBM.com, start by opening a <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose" target="_blank">GitHub issue</a> and select Feature Request.
+
+Include a detailed description in which you:
+
+- Explain the rationale for the request
+- Detail the intent and/or usage
+- Clarify whether it's a variation of an existing component, or a new component
+- Include mockups of any fidelity (optional)
+- Include any inspirations from other products (optional)
+- Include component guidance
 
 ## How to write component guidance
 
@@ -329,15 +342,3 @@ For guidance, see our Documentation requirements section above or reach out to u
 #### 5. Working code
 
 The component for **Carbon for IBM.com** must be built in one of our supported frameworks - React or Web Components. We'd like to prioritize working on Web Components since it has become our strategic direction. If you need help learning how to build it in Web Components, reach out to the engineers in our slack channel for training <a href="https://ibm-studios.slack.com/archives/C2PLX8GQ6" target="_blank">#carbon-for-ibm-dotcom</a>. Please read the [Developer guide](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/docs/developing.md) and the [Submissions guidelines](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/main/docs/submission-guidelines.md) for more details.
-
-## Steps to contributing
-
-To contribute a component to Carbon for IBM.com, start by opening a <a href="https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose" target="_blank">GitHub issue</a> and select Feature Request.
-
-Include a detailed description in which you:
-
-- Explain the rationale for the request
-- Detail the intent and/or usage
-- Clarify whether it's a variation of an existing component, or a new component
-- Include mockups of any fidelity (optional)
-- Include any inspirations from other products (optional)


### PR DESCRIPTION
This PR changes the order slightly of the three topics on the page. Moving `Steps to contributing` to the top where it can act as an overview. Also added creating component guidance as one of the steps. 