### PR TITLE
docs(environments): remove all mybluemix.net urls

### DIFF
--- a/src/data/components.json
+++ b/src/data/components.json
@@ -385,7 +385,7 @@
       "functionalLink": false,
       "description": "Language selector is for users to select their preferred language on a website. The content on the website will appear in the default language until the users reselect their preferred language then the page content will reload in the reselected language provided a translation is available.",
       "storybook": {
-        "webcomponents": "http://ibmdotcom-web-components-canary.mybluemix.net/?path=/story/components-footer--default-language-only",
+        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-footer--default-language-only",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-footer--default-language-only"
       },
       "webcomponents": {

--- a/src/pages/developing/other-packages/index.mdx
+++ b/src/pages/developing/other-packages/index.mdx
@@ -45,16 +45,6 @@ Carbon for IBM.com will no longer be maintained. <Link to="/help/expressive-upda
 </ResourceCard>
 </Column>
 
-<Column colMd={4} colLg={4} noGutterSm>
-<ResourceCard
-  subTitle="Carbon Expressive Theme"
-  href="https://carbon-expressive.mybluemix.net"
->
-
-![React icon](./../../../images/icon/react-icon.svg)
-
-</ResourceCard>
-</Column>
 </Row>
 
 ### Services and utilities
@@ -78,7 +68,7 @@ packages. They are exported as pure ES6 classes.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Services API Documentation"
-  href="https://ibmdotcom-services.mybluemix.net"
+  href="https://carbon-design-system.github.io/carbon-for-ibm-dotcom/services/"
 >
 
 ![JSDoc](./../../../images/icon/js_logo.svg)
@@ -100,7 +90,7 @@ packages. They are exported as pure ES6 classes.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Utilities API Documentation"
-  href="https://ibmdotcom-utilities.mybluemix.net"
+  href="https://carbon-design-system.github.io/carbon-for-ibm-dotcom/utilities/"
 >
 
 ![JSDoc](./../../../images/icon/js_logo.svg)

--- a/src/pages/developing/web-components-tutorial/step-4.mdx
+++ b/src/pages/developing/web-components-tutorial/step-4.mdx
@@ -76,7 +76,7 @@ These components will be showcased at the bottom using the `Tabs` components, so
 The following Carbon components that will be used in step 4 are:
 
 - [Tag](https://web-components.carbondesignsystem.com/?path=/story/components-tag--default)
-- [Tag group](https://ibmdotcom-web-components-canary.mybluemix.net/?path=/story/components-tag-group--default)
+- [Tag group](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-tag-group--default)
 - [Tabs](https://web-components.carbondesignsystem.com/?path=/story/components-tabs--default)
 - [Data table](https://web-components.carbondesignsystem.com/?path=/story/components-data-table--default)
 - [Dropdown](https://web-components.carbondesignsystem.com/?path=/story/components-dropdown--default)

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -104,7 +104,7 @@ IBM.com.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Services"
-  href="https://ibmdotcom-services.mybluemix.net"
+  href="https://carbon-design-system.github.io/carbon-for-ibm-dotcom/services/"
 >
 
 ![GitHub icon](./../../images/icon/github-icon.svg)
@@ -114,7 +114,7 @@ IBM.com.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Utilities"
-  href="https://ibmdotcom-utilities.mybluemix.net"
+  href="https://carbon-design-system.github.io/carbon-for-ibm-dotcom/utilities/"
 >
 
 ![GitHub icon](./../../images/icon/github-icon.svg)


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This removes all IBM Cloud links from the repo and switches to the latest ones.

### Changelog

**Changed**

- All links from mybluemix.net to the corresponding Github Pages or production links

**Removed**

- Removed Carbon Expressive Theme card
