### PR TITLE
fix(links): remove fragment from style-model link

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -58,7 +58,7 @@
     - title: Spacing
       path: /guidelines/spacing
     - title: Style models
-      path: /guidelines/style-models/overview
+      path: /guidelines/style-models
 
 - title: Components
   pages:


### PR DESCRIPTION
### Description

Fixes `Style models` link in left nav.

### Changelog

**Removed**

- remove unneeded anchor fragment from `style-models` url
