### PR TITLE
test(cypress): add retries config and increase timeout

### DIFF
--- a/tests/e2e/cypress-prod.json
+++ b/tests/e2e/cypress-prod.json
@@ -9,6 +9,10 @@
   "supportFile": "tests/e2e/cypress/support/index.js",
   "pluginsFile": "tests/e2e/cypress/plugins/index.js",
   "testFiles": "**/*.e2e.js",
-  "pageLoadTimeout": 60000,
-  "defaultCommandTimeout": 60000
+  "pageLoadTimeout": 90000,
+  "defaultCommandTimeout": 90000,
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }

--- a/tests/e2e/cypress.json
+++ b/tests/e2e/cypress.json
@@ -9,6 +9,10 @@
   "supportFile": "tests/e2e/cypress/support/index.js",
   "pluginsFile": "tests/e2e/cypress/plugins/index.js",
   "testFiles": "**/*.e2e.js",
-  "pageLoadTimeout": 60000,
-  "defaultCommandTimeout": 60000
+  "pageLoadTimeout": 90000,
+  "defaultCommandTimeout": 90000,
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

Noticing sporadic timeouts on production, this will add retries to the Cypress config as well as an increased timeout for tests.

### Changelog

**Changed**

- add `retries` to `cypress.json` and `cypress-prod.json`
