### PR TITLE
fix: remove extra next/prev button top padding on homepage

### DIFF
--- a/src/styles/_homepage.scss
+++ b/src/styles/_homepage.scss
@@ -42,3 +42,7 @@
   position: relative;
   z-index: 2;
 }
+
+.container--homepage div[class*='NextPrevious-module--grid'] {
+  padding-top: 0;
+}


### PR DESCRIPTION
### Related Ticket(s)

#1447

### Description

This PR removes the extra top padding on the next/previous buttons on the website homepage

<img width="1125" alt="image" src="https://user-images.githubusercontent.com/8265238/153025447-61de0770-1912-4de7-86ce-5985ef7247e2.png">
