### PR TITLE
Update aside element in Figma kit page

### DIFF
--- a/src/pages/designing/figma-kit.mdx
+++ b/src/pages/designing/figma-kit.mdx
@@ -45,15 +45,7 @@ Unlike Sketch, Figma does not need time to "install" or "download" a library fil
 
 **Figma access**
 
-IBMers can learn more about accessing Figma in the
-
-<a
-  href="https://w3.ibm.com/design/toolbox/#/ui-design-tools/figma/README"
-  target="_blank"
-  rel="noopener noreferrer"
->
-  Design Toolbox
-</a>
+IBMers can learn more about accessing Figma in the <a href="https://w3.ibm.com/design/toolbox/#/ui-design-tools/figma/README" target="_blank" rel="noopener noreferrer" >Design Toolbox</a>
 
   </Aside>
 </Column>


### PR DESCRIPTION
Trying to fix the line break in the link on the aside element on the Figma kit page

### Related Ticket(s)

Closes #1482 

### Description

Fix the line break in the aside element
<img width="244" alt="Screen Shot 2022-05-23 at 10 37 21 AM" src="https://user-images.githubusercontent.com/45692622/169844065-f75dd74d-ff7f-4671-a025-9a084f394e79.png">



### Changelog

**New**

- {{new thing}}

**Changed**

- remove line break

**Removed**

- {{removed thing}}
