### PR TITLE
Update sketch kit aside element

### DIFF
--- a/src/pages/designing/sketch-kit.mdx
+++ b/src/pages/designing/sketch-kit.mdx
@@ -44,16 +44,7 @@ assets available for adopters as soon as possible.
 
 **Sketch access**
 
-IBMers can learn more about accessing Sketch in the
-
-<a
-  href="https://w3.ibm.com/design/toolbox/#/ui-design-tools/sketch/README"
-  target="_blank"
-  rel="noopener noreferrer"
->
-  Design Toolbox
-</a>
-.
+IBMers can learn more about accessing Sketch in the <a href="https://w3.ibm.com/design/toolbox/#/ui-design-tools/sketch/README" target="_blank" rel="noopener noreferrer">Design Toolbox</a>.
 
   </Aside>
 </Column>


### PR DESCRIPTION
Updating the Sketch kit aside element to remove the line break

### Related Ticket(s)

Closes #1482 

### Description

Fix the line break in the aside element on the Sketch kit page
<img width="259" alt="Screen Shot 2022-05-23 at 11 10 31 AM" src="https://user-images.githubusercontent.com/45692622/169850731-0f2c0226-a7a2-4c5d-bd5f-bc229791b418.png">


### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- removed extra space so link does not break onto another line
