### PR TITLE
Universal banner - Fixed resource card location

### DIFF
--- a/src/pages/components/universal-banner.mdx
+++ b/src/pages/components/universal-banner.mdx
@@ -22,6 +22,8 @@ import ResourceLinks from 'components/ResourceLinks';
 
 </AnchorLinks>
 
+<ResourceLinks name="Universal banner" type="layout" />
+
 ## Overview
 
 Universal banner is intended for high level and critical announcements such as IBM's THINK global event or COVID-19 messaging. The banner is the only component that can be positioned above the masthead. It has a max height to encourage succinct messaging and optional fields for an image, heading, body copy, and CTA.
@@ -76,8 +78,6 @@ The Universal banner adapts its visuals and interactions on `sm` and `md` breakp
 <Caption>
   Example of the universal banner at the medium and small breakpoints
 </Caption>
-
-<ResourceLinks name="Universal banner" type="layout" />
 
 ## Content guidance for banner with text only
 


### PR DESCRIPTION
### Related Ticket(s)

[#9027](https://app.zenhub.com/workspaces/carbon-for-ibmcom-5d449f3642eb1962336cbe52/issues/carbon-design-system/carbon-for-ibm-dotcom/9027)

### Description

Update resource card links for `Universal banner` page to appear at the top of the page.

### Changelog

**New**

- N/A

**Changed**

- Changed location of resource cards

**Removed**

- N/A
