### PR TITLE
chore(docs): add specific info about tagged cdn versions

### DIFF
--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -71,12 +71,13 @@ To see all available CDN links, visit the `Docs` tab for the corresponding compo
 
 All components are available either by moving tag versions, or specific versions (starting at `v1.6.0`).
 
-The latest/next/beta tags are moving versions. While beneficial to always stay on the most recent version, it is
-recommended to choose a specific version and properly test your application when upgrading to a newer version.
+The `latest`/`next`/`beta` tags are moving versions. When latest/next tags are updated, Akamai caches can take up to 24 hours to clear, which could result in instability during that time. It is highly recommended to instead use a specific version for applications on production and to properly test your application when upgrading to a newer version
+
+Please ensure only one version of artifacts is used at a time, having multiple versions will cause rendering issues.
 
 | Tag      | Description                                                                                                                                                                                               |
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `latest` | Updated with every full release                                                                                                                                                                           |
+| `latest` | Updated on Friday at 6pm EST with every full release                                                                                                                                                      |
 | `next`   | Updated with every release candidate during code freeze periods. See our release schedule at the pinned issue on our [issue board](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues). |
 | `beta`   | Updated every two weeks                                                                                                                                                                                   |
 

--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -71,7 +71,7 @@ To see all available CDN links, visit the `Docs` tab for the corresponding compo
 
 All components are available either by moving tag versions, or specific versions (starting at `v1.6.0`).
 
-The `latest`/`next`/`beta` tags are moving versions. When latest/next tags are updated, Akamai caches can take up to 24 hours to clear, which could result in instability during that time. It is highly recommended to instead use a specific version for applications on production and to properly test your application when upgrading to a newer version
+The `latest`/`next` tags are moving versions. When `latest`/`next` tags are updated, Akamai caches can take up to 24 hours to clear, which could result in instability during that time. It is highly recommended to instead use a specific version for applications on production and to properly test your application when upgrading to a newer version
 
 Please ensure only one version of artifacts is used at a time, having multiple versions will cause rendering issues.
 
@@ -79,7 +79,6 @@ Please ensure only one version of artifacts is used at a time, having multiple v
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `latest` | Updated on Friday at 6pm EST with every full release                                                                                                                                                      |
 | `next`   | Updated with every release candidate during code freeze periods. See our release schedule at the pinned issue on our [issue board](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues). |
-| `beta`   | Updated every two weeks                                                                                                                                                                                   |
 
 Here are examples of setting by tag:
 


### PR DESCRIPTION
### Related Ticket(s)

[[Documentation]: Update storybook and website documentation about using tagged versions of Carbon for IBM.com](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9138)

### Description

Add more specific information about CDN tagged versions in Frameworks section.

<img width="836" alt="Screen Shot 2022-07-26 at 1 07 33 PM" src="https://user-images.githubusercontent.com/54281166/181102691-07455334-089f-4eb0-b38c-0fb95bb4e1a3.png">


### Changelog

**Changed**

- add specific wording about the tagged CDN version in the Frameworks section of the website
- remove `beta` tag documentation as we no longer provide that tag
