### PR TITLE
fix(nav): remove guidelines/overview link

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -41,8 +41,6 @@
 
 - title: Guidelines
   pages:
-    - title: Overview
-      path: /guidelines
     - title: Content
       path: /guidelines/content
     - title: Expressive styling


### PR DESCRIPTION
### Description

There is no `overview` page for the Guidelines section. This removes the link from the left nav.

### Changelog

**Removed**

- `guidelines/overview` link from left nav
