### PR TITLE
[Website] Figma White theme Beta update

### DIFF
--- a/src/pages/designing/figma-kit.mdx
+++ b/src/pages/designing/figma-kit.mdx
@@ -10,6 +10,12 @@ type styles, color tokens, and components.
 
 </PageDescription>
 
+<InlineNotification>
+
+**Beta White theme is now available!** The _Carbon for IBM.com (White Theme)_ is now available to internal users. The library is marked as BETA as we continue to add new components and update the library. As we make updates, some components may receive breaking changes due to these enhancements. The previous library, 🚫 _Carbon for IBM.com (White theme) Beta [To be deprecated]_, will be deprecated one month after the release of the new Beta library. You may need to switch instances of components to the new library to stay current with updates.
+
+</InlineNotification>
+
 <AnchorLinks>
 
 <AnchorLink>Accessing the new Figma kit</AnchorLink>
@@ -37,7 +43,7 @@ Unlike Sketch, Figma does not need time to "install" or "download" a library fil
 
 1. In the menu, click the Figma dropdown then select `Libraries`. Alternatively, click the `Asset` panel, and then the open book, or `Library` icon.
 2. In the Libraries list, search for `Carbon for IBM.com`.
-3. Select the theme to enable.
+3. Select the theme to enable. Note that any themes marked with 🚫 and have _[To be deprecated]_ in the name will eventually be removed. You may need to swap instances with new libraries as they are released.
 
 </Column>
 <Column colMd={2} colLg={3} offsetMd={1} offsetLg={1}>


### PR DESCRIPTION
### Related Ticket(s)

#9292

### Description

Updated alert and content in `Figma kit` design page to be released along with the new Beta Figma theme library.

### Changelog

**New**

- N/A

**Changed**

- Alert and language in `Figma kit` page

**Removed**

- N/A
