### PR TITLE
chore(help): tweaks to help content

### DIFF
--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -31,6 +31,9 @@ Answers to the most common questions about the design system can be found in the
 
 _Internal IBM users only. The Carbon for IBM.com core team maintains the following channels and will provide support as time permits._
 
+- [#carbon-for-ibm-dotcom](https://ibm-studios.slack.com/archives/C2PLX8GQ6)
+- [#carbon-web-components](https://ibm-studios.slack.com/archives/CL83LMKSA)
+
 **Please try searching the Slack channel for your topic first.** Slack’s filtering feature will return more targeted and relevant results. For instance, if you have a technical question about the DataTable component, you could search “DataTable” in Slack and then filter by the #carbon-for-ibm-dotcom channel.
 
 _Tip: You can start a new search directly from the message box using the /s slash command._
@@ -57,9 +60,7 @@ Bug reports, feature requests, and general feedback can be delivered to the Carb
 
 **Code issues**
 
-- [Bug](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new?labels=bug&template=bug_report.md)
-- [React components](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose)
-- [React patterns](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose)
+- [Bugs/Feature Requests](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose)
 
 ## Resources
 


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

Some minor tweaks to the help page, some links were out of date or missing.

### Changelog

**Changed**

- Added list of slack channels and links to them
- Adjusted links for code issues (it was going to a non-template version of bug creation)

