### PR TITLE
chore(help): add office hours section

### DIFF
--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -105,7 +105,7 @@ Bug reports, feature requests, and general feedback can be delivered to the Carb
       href="https://ec.yourlearning.ibm.com/w3/event/10289727"
       >
 
-    ![Slack icon](../../images/icon/bee_icon.svg)
+![Slack icon](../../images/icon/bee_icon.svg)
 
   </ResourceCard>
 </Column>

--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -75,5 +75,25 @@ Bug reports, feature requests, and general feedback can be delivered to the Carb
 ![Slack icon](../../images/icon/slack-mark.svg)
 
   </ResourceCard>
+    <ResourceCard
+      subTitle="Design Office Hours"
+      aspectRatio="2:1"
+      actionIcon="launch"
+      href="https://ec.yourlearning.ibm.com/w3/event/10289722"
+      >
+
+![Slack icon](../../images/icon/bee_icon.svg)
+
+  </ResourceCard>
+    <ResourceCard
+      subTitle="Development Office Hours"
+      aspectRatio="2:1"
+      actionIcon="launch"
+      href="https://ec.yourlearning.ibm.com/w3/event/10289727"
+      >
+
+    ![Slack icon](../../images/icon/bee_icon.svg)
+
+  </ResourceCard>
 </Column>
 </Row>

--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -84,6 +84,8 @@ Bug reports, feature requests, and general feedback can be delivered to the Carb
 ![Slack icon](../../images/icon/slack-mark.svg)
 
   </ResourceCard>
+</Column>
+<Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="Design Office Hours"
       aspectRatio="2:1"
@@ -94,6 +96,8 @@ Bug reports, feature requests, and general feedback can be delivered to the Carb
 ![Slack icon](../../images/icon/bee_icon.svg)
 
   </ResourceCard>
+</Column>
+<Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="Development Office Hours"
       aspectRatio="2:1"

--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -35,6 +35,15 @@ _Internal IBM users only. The Carbon for IBM.com core team maintains the followi
 
 _Tip: You can start a new search directly from the message box using the /s slash command._
 
+### Office hours
+
+_Internal IBM users only._
+
+Need help using the design system? Come to the Carbon for IBM.com weekly office hours! Feel free to join just to listen, or sign up ahead of the time with projects to discuss.
+
+- [Design office hours](https://ec.yourlearning.ibm.com/w3/event/10289722)
+- [Development office hours](https://ec.yourlearning.ibm.com/w3/event/10289727)
+
 ## Suggestions or contributions
 
 ### GitHub pull requests


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

The help section was missing office hours, so opened a change for this.

### Changelog

**Changed**

- Added section and resource cards for office hours
