### PR TITLE
Tweaks to spacing page

### DIFF
--- a/src/pages/guidelines/spacing.mdx
+++ b/src/pages/guidelines/spacing.mdx
@@ -20,9 +20,9 @@ Carbon for IBM.com uses uniform components, elements, and spacing to encourage c
 
 ## Designing with space
 
-Every part of a UI should be intentional, including the empty space, also known as white space, between elements. The amount of space between items creates relationships and hierarchy. You can learn more about white space and how space can help you create relationships and hierarchy on the [Carbon spacing guideline page](https://www.carbondesignsystem.com/guidelines/spacing/overview/#designing-with-space).
+Every part of a UI should be intentional, including the empty space, also known as white space, between elements. The amount of space between items creates relationships and hierarchy. You can learn more about white space and how space can help you create relationships and hierarchy on the [Carbon spacing guidelines](https://www.carbondesignsystem.com/guidelines/spacing/overview/#designing-with-space) page.
 
-When designing for IBM.com, the spacing scale and type tokens are used to ensure the information is well organized with consistency.
+When designing for IBM.com, the spacing scale and type tokens are used to ensure the information is well organized with consistency, see the [Type pairings guidance](../expressive-styling/type-pairing) to learn more about the type hierarchy of the Carbon for IBM.com components.
 
 <br />
 
@@ -105,7 +105,7 @@ designs. This scale is applied and used within all Carbon components.
 
 #### Are there any differences when designing with expressive type sets vs. productive type sets?
 
-Yes, please see the [Type pairing guideline](https://www.ibm.com/standards/carbon/guidelines/type-pairing) to learn more.
+Yes, please see the [Expressive styling](../expressive-styling/overview) to learn more about styling strategies and type pairings.
 
 #### Are there any other spacing options besides the one listed in the Spacing scale and token section?
 
@@ -127,11 +127,11 @@ applying it to fit the 5% grid margins.
 
 No, the tokens themselves do not change values based on the screen size.
 However, it is acceptable at page breakpoints to jump a step(s) on the spacing
-scale to fit spacing needs (i.e., at 1440 px `padding-right: $spacing-05` but at
-breakpoint 768px `padding-right: $spacing-03`).
+scale to fit spacing needs (i.e., at 1312px `padding-right: $spacing-05` but at
+breakpoint 672px `padding-right: $spacing-03`).
 
 <br />
 
 ## Support
 
-If you need additional guidance on designing with space, please reach out to the Digital Design System team via the [#carbon-for-ibm-dotcom slack channel](https://cognitive-app.slack.com/archives/C2PLX8GQ6).
+If you need additional guidance on designing with space, please reach out to the Carbon for IBM.com team via the [#carbon-for-ibm-dotcom slack channel](https://cognitive-app.slack.com/archives/C2PLX8GQ6).

--- a/src/pages/guidelines/spacing.mdx
+++ b/src/pages/guidelines/spacing.mdx
@@ -22,7 +22,7 @@ Carbon for IBM.com uses uniform components, elements, and spacing to encourage c
 
 Every part of a UI should be intentional, including the empty space, also known as white space, between elements. The amount of space between items creates relationships and hierarchy. You can learn more about white space and how space can help you create relationships and hierarchy on the [Carbon spacing guidelines](https://www.carbondesignsystem.com/guidelines/spacing/overview/#designing-with-space) page.
 
-When designing for IBM.com, the spacing scale and type tokens are used to ensure the information is well organized with consistency, see the [Type pairings guidance](../expressive-styling/type-pairing) to learn more about the type hierarchy of the Carbon for IBM.com components.
+When designing for IBM.com, the spacing scale and type tokens are used to ensure the information is well organized with consistency. See the [Type pairings guidance](../expressive-styling/type-pairing) to learn more about the type hierarchy of the Carbon for IBM.com components.
 
 <br />
 


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

Minor fixes to the spacing page and linking to guidelines

### Changelog

- Updated DDS to Carbon for IBM.com team
- Added links to type pairing 
- Updated expressive guideline link
