### PR TITLE
Content section remove notification

### DIFF
--- a/src/pages/components/content-section.mdx
+++ b/src/pages/components/content-section.mdx
@@ -70,7 +70,7 @@ page, interrupting the reading experience for the user.
 #### When not to use
 
 Do not use a Content section to separate only content items, or other related basic content items (like paragraphs)
-inside a web page. Use a Content group instead.
+inside a web page. Use a [Content group](https://www.ibm.com/standards/carbon/components/content-group) instead.
 
 ## Behaviors
 

--- a/src/pages/components/content-section.mdx
+++ b/src/pages/components/content-section.mdx
@@ -24,7 +24,7 @@ import ResourceLinks from 'components/ResourceLinks';
 
 </AnchorLinks>
 
-<ResourceLinks name="Content block" type="layout" />
+<ResourceLinks name="Content section" type="layout" />
 
 ## Overview
 

--- a/src/pages/components/content-section.mdx
+++ b/src/pages/components/content-section.mdx
@@ -12,12 +12,6 @@ import ResourceLinks from 'components/ResourceLinks';
 
 <ComponentDescription name="Content section" type="layout" />
 
-<InlineNotification>
-
-**Note:** This component is currently in development and will be available soon.
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Resources</AnchorLink>


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

The `Content section` page needed an update to remove the notification, update the resource links so they didn't send users to `Content block` resources, and an added in-line link to `Content group`.

### Changelog

**New**

- N/A

**Changed**

- Resource links updated to send to `Content section` content.
- Added in-line link to `Content group`.

**Removed**

- Notification announcing new content
