### PR TITLE
Resources fix broken links to storybook

### DIFF
--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -63,7 +63,7 @@ IBM.com.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Carbon for IBM.com Storybook Web Components"
-  href="https://www.ibm.com/standards/carbon/web-components/"
+  href="https://www.ibm.com/standards/carbon/web-components"
 >
 
 ![Web components icon](../../images/icon/web-components-icon.svg)
@@ -74,7 +74,7 @@ IBM.com.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Carbon for IBM.com Storybook React"
-  href="https://www.ibm.com/standards/carbon/react/"
+  href="https://www.ibm.com/standards/carbon/react"
 >
 
 ![React icon](../../images/icon/react-icon.svg)
@@ -85,7 +85,7 @@ IBM.com.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Carbon for IBM.com Storybook React wrapper"
-  href="https://www.ibm.com/standards/carbon/web-components/react/"
+  href="https://www.ibm.com/standards/carbon/web-components/react"
 >
 
 ![React icon](../../images/icon/react-icon.svg)


### PR DESCRIPTION
### Related Ticket(s)

Still getting a 404 on the Storybook links on the Resources pages

### Description

removing `/` at the end of all links