### PR TITLE
Typo fix: from “broswer” to “browser”

### DIFF
--- a/src/pages/components/masthead.mdx
+++ b/src/pages/components/masthead.mdx
@@ -154,7 +154,7 @@ For the product navigation pattern, please see the [Global header Pattern](https
 
 #### Max breakpoint
 
-If the broswer is wider than the max breakpoint of 1584px, the masthead and all other page content will center and extra margin will appear on either side of the page layout.
+If the browser is wider than the max breakpoint of 1584px, the masthead and all other page content will center and extra margin will appear on either side of the page layout.
 
 ![Masthead component level 1 max breakpoint behavior image](../../images/component/masthead/masthead-l1-behavior-max-breakpoint.png)
 


### PR DESCRIPTION
https://www.ibm.com/standards/carbon/components/masthead#behavior

<img width="203" alt="Screen Shot 2022-10-10 at 2 09 47 PM" src="https://user-images.githubusercontent.com/32881239/194936784-cda7102b-58e5-4b08-ad33-023c0d94d0d1.png">
