### PR TITLE
fix(step-1): update to use HTML commits

### DIFF
--- a/src/pages/developing/web-components-tutorial/step-1.mdx
+++ b/src/pages/developing/web-components-tutorial/step-1.mdx
@@ -422,7 +422,7 @@ To wrap up this tutorial step, let's add the required meta tags for an IBM.com p
 
 <link rel="icon" href="//www.ibm.com/favicon.ico" />
 
-<meta name="dcterms.date" content="YYYY-MM-DD" /> // replace with today's date
+<meta name="dcterms.date" content="YYYY-MM-DD" /> <!--  replace with today's date -->
 <meta name="dcterms.rights" content="© Copyright IBM Corp. 2021" />
 <meta name="geo.country" content="US" />
 <meta name="robots" content="index,follow" />


### PR DESCRIPTION
### Related Ticket(s)

N/A 
### Description

When user's copy and paste the meta tags and include the comment `replace with today's date` then it causes there tests to fail because it's using the wrong type of commit tag. 

### Changelog

**Changed**

- update to HTML commiting

