### PR TITLE
[Fix] Remove extra anchor link

### DIFF
--- a/src/pages/components/tags.mdx
+++ b/src/pages/components/tags.mdx
@@ -11,7 +11,6 @@ import ResourceLinks from 'components/ResourceLinks';
 
 <AnchorLinks>
 
-<AnchorLink>Resources</AnchorLink>
 <AnchorLink>Overview</AnchorLink>
 <AnchorLink>Tag</AnchorLink>
 <AnchorLink>Tag link</AnchorLink>


### PR DESCRIPTION

### Related Ticket(s)

NA

### Description

Looks like the "Resources" section was removed but the anchor link left behind. This PR removes the non-functioning anchor link for "Resources"

### Changelog

**Removed**

- "Resources" anchor link from top of page 
