### PR TITLE
[Table of contents] Added When to use section to Vertical

### DIFF
--- a/src/pages/components/table-of-contents.mdx
+++ b/src/pages/components/table-of-contents.mdx
@@ -42,13 +42,13 @@ The Table of contents (ToC) component renders as left navigation that includes a
 
 <Caption>Example of the default Table of contents within a page.</Caption>
 
-**When to use:**
+#### When to use:
 
 - When the page length is long and requires a lot of scrolling.
 - When users need to know what is included in a page, the table of contents can serve as an outline or summary of the page content.
 - When users need to navigate to a specific section on the page quickly.
 
-**When not to use:**
+#### When not to use:
 
 - When there is only one section, there is no need to include the ToC
 - When a page is relatively short and the user will not have to scroll very far.
@@ -66,12 +66,12 @@ The horizontal variation displays the Table of content navigation links in a row
 
 <Caption>Example of the horizontal Table of contents within a page.</Caption>
 
-**When to use:**
+#### When to use:
 
 - Your experience needs to use full width section components or the first four columns of the 2x grid.
 - The Table of contents needs to be used across alternating full width themed sections throughout a page.
 
-**When not to use:**
+#### When not to use:
 
 - The horizontal version should not be used with a center aligned lead space because the text alignment disrupts the user's reading flow. In that situation, consider using the vertical version with Lead space centered or Lead space block.
 - The horizontal version should not be placed immediately below the IBM masthead.
@@ -87,6 +87,15 @@ This variation only applies to the vertical Table of contents (ToC). The area ab
 <Caption>
   Example of the vertical Table of contents with heading content.
 </Caption>
+
+#### When to use:
+
+- The vertical version can take up the first four columns of the 2x grid to help the user navigate related content.
+
+#### When not to use:
+
+- The vertical version should not be used when any of the associated content components uses a different theme (for example, the page theme is White, but one of the table of contents components uses a Gray 100 theme). In that situation, consider using only one theme throughout the vertical table of contents or using the horizontal version instead.
+- The vertical version should not contain any components that use a section header.
 
 ## Behaviors
 


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

Added a When to use/When not to use section to `table of contents`.

### Changelog

**New**

- New When to use/When not to use for `table of contents` vertical version.

**Changed**

- Updated bolded headers to `h4` headers for When to use/When not to use sections. This way they would have consistent spacing between header and list items.

**Removed**

- N/A
