### PR TITLE
[Card – pictogram] Added alert for bottom alignment

### DIFF
--- a/src/pages/components/cards.mdx
+++ b/src/pages/components/cards.mdx
@@ -126,7 +126,7 @@ visual associations. However, keep in mind that meanings of pictograms can diffe
 should be selected and used carefully. For information about content in pictogram cards, see the
 [content guidance table](#content-guidance-for-pictogram-card).
 
-Cards with pictograms offer two pictogram positions: top-aligned or bottom-aligned. We highly recommend using the bottom-aligned layout to achieve proper alignment in the updated card changes coming with Carbon v11.
+Cards with pictograms offer two pictogram positions: top-aligned or bottom-aligned.
 
 <InlineNotification>
 

--- a/src/pages/components/cards.mdx
+++ b/src/pages/components/cards.mdx
@@ -130,7 +130,7 @@ Cards with pictograms offer two pictogram positions: top-aligned or bottom-align
 
 <InlineNotification>
 
-**Alignment:** We highly recommend using the bottom-aligned layout to achieve proper alignment in the updated card changes coming with Carbon v11.
+**Alignment:** We highly recommend using the bottom-aligned layout to achieve consistency with the updated [Carbon tile guidance](https://carbondesignsystem.com/components/tile/usage/).
 
 </InlineNotification>
 

--- a/src/pages/components/cards.mdx
+++ b/src/pages/components/cards.mdx
@@ -126,7 +126,13 @@ visual associations. However, keep in mind that meanings of pictograms can diffe
 should be selected and used carefully. For information about content in pictogram cards, see the
 [content guidance table](#content-guidance-for-pictogram-card).
 
-Cards with pictograms offer two pictogram positions: top-aligned or bottom-aligned.
+Cards with pictograms offer two pictogram positions: top-aligned or bottom-aligned. We highly recommend using the bottom-aligned layout to achieve proper alignment in the updated card changes coming with Carbon v11.
+
+<InlineNotification>
+
+**Alignment:** We highly recommend using the bottom-aligned layout to achieve proper alignment in the updated card changes coming with Carbon v11.
+
+</InlineNotification>
 
 <Row>
 <Column colMd={8} colLg={8}>


### PR DESCRIPTION
### Related Ticket(s)

[#10127](https://github.com/orgs/carbon-design-system/projects/56/views/11?pane=issue&itemId=21532320)

### Description

Added alert on `card – pictogram` page to tell adopters to lean on the bottom alignment to help with v11 migration styles

### Changelog

**New**

- Alert content on `card – pictogram` page

**Changed**

- N/A

**Removed**

- N/A
