### PR TITLE
tabs-extended-grammar-fix

### DIFF
--- a/src/pages/components/tabs-extended.mdx
+++ b/src/pages/components/tabs-extended.mdx
@@ -22,7 +22,7 @@ import ResourceLinks from 'components/ResourceLinks';
 
 ## Overview
 
-Tabs are useful for displaying parallel pieces of content that share the same context. It has the additional benefit of reducing screen height, but should be used careful because some information are hidden on load.
+Tabs are useful for displaying parallel pieces of content that share the same context. It has the additional benefit of reducing screen height, but should be used carefully because some information is hidden on load.
 
 Our Tabs extended component references the Carbon Design System's [tabs component](https://carbondesignsystem.com/components/tabs/usage/), and it is built with additional features to optimize for editorial content.
 
@@ -84,7 +84,7 @@ For more information, see the [character count standards](https://www.ibm.com/st
 
 ## Tabs extended media
 
-Tabs extended provides an option to include media. It uses [Content item horizontal](/components/content-item-horizontal) with media to create an organized section for displaying content with media. This is useful especially when reducing page length is desired. Keep in mind that when using tabs, some content will be hidden until the user interacts with the component, so they should not be used for information that is considered critical.
+Tabs extended with media provides an option where the tab panel is pre-populated with the [Content item horizontal](/components/content-item-horizontal) with media component to create an organized section for displaying content paired with media. Keep in mind that when using tabs, some content will be hidden until the user interacts with the component, so they should not be used for information that is considered critical.
 
 <Row>
 <Column colMd={8} colLg={8}>


### PR DESCRIPTION
### Related Ticket(s)

Minor fixes found during the #1574 


### Changelog

**New**

- n/a

**Changed**

- fixed grammar mistake 
- how we talk about tabs extended with media

**Removed**

- "reduce page length"
