### PR TITLE
Docs--Content-group--remove-persistent-line

### DIFF
--- a/src/pages/components/content-group.mdx
+++ b/src/pages/components/content-group.mdx
@@ -100,6 +100,7 @@ alternating with a content group accepting 4 cards in a children container (a Ca
 
 ## Tips and techniques
 
+
 Keep in mind that the Content group children container is positioned between the Content group description and the card
 link.
 

--- a/src/pages/components/content-group.mdx
+++ b/src/pages/components/content-group.mdx
@@ -100,7 +100,6 @@ alternating with a content group accepting 4 cards in a children container (a Ca
 
 ## Tips and techniques
 
-
 Keep in mind that the Content group children container is positioned between the Content group description and the card
 link.
 

--- a/src/pages/components/content-group.mdx
+++ b/src/pages/components/content-group.mdx
@@ -100,8 +100,6 @@ alternating with a content group accepting 4 cards in a children container (a Ca
 
 ## Tips and techniques
 
-Content group elements are persistent throughout the online experience.
-
 Keep in mind that the Content group children container is positioned between the Content group description and the card
 link.
 


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

Removed line for `content group` page – "Content group elements are persistent throughout the online experience." Line is unclear and may be mistaken to mean "fixed" or "sticky". 

### Changelog

**New**

- N/A

**Changed**

- N/A

**Removed**

- Remove one line in `content group` page.
