### PR TITLE
Docs - Lead space search minor language edit

### DIFF
--- a/src/pages/components/content-group.mdx
+++ b/src/pages/components/content-group.mdx
@@ -100,8 +100,6 @@ alternating with a content group accepting 4 cards in a children container (a Ca
 
 ## Tips and techniques
 
-Content group elements are persistent throughout the online experience.
-
 Keep in mind that the Content group children container is positioned between the Content group description and the card
 link.
 

--- a/src/pages/components/lead-space-search.mdx
+++ b/src/pages/components/lead-space-search.mdx
@@ -107,7 +107,7 @@ Lead space search includes a `skip to main content` option for keyboard users so
 
 ### Mobile breakpoints (md, sm)
 
-The search component spans 8/8 columns of the grid for the `md` breakpoint and 4/4 columns of the grid for the `sm` breakpoint.
+The search component spans 8 columns of the grid for the `md` breakpoint and 4 columns of the grid for the `sm` breakpoint.
 
 The component can scroll with the page, or adopt a sticky behaviour for the search container. There is no option to display a sticky heading because the search component takes the maximum number of columns.
 


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

In this one-off case we refer to `8/8 columns` and `4/4 columns`, but on the rest of the page we don't introduce the number of columns like that. Simplifying to `8 columns` and `4 columns` respectively.

### Changelog

**New**

- n/a

**Changed**

- Minor language update

**Removed**

- n/a
