### PR TITLE
Sketch kit support updates

### DIFF
--- a/src/pages/designing/index.mdx
+++ b/src/pages/designing/index.mdx
@@ -34,8 +34,11 @@ Carbon for IBM.com is just one part of the IBM ecosystem and you may have to go 
 <Row>
 <Column  colLg={8} colMd={8} colSm={4}>
 
-Carbon for IBM.com has two design kits—Sketch and Figma. By using the kits you
-automatically get any updates made by the Carbon for IBM.com team so you don’t
+_For IBMers only:_
+
+IBMers should get a license for Figma, our primary design kit tool. You may also access Sketch, however, we no longer maintain or update the Sketch kit. We recommend you migrate to Figma to get the most updated assets we offer. 
+
+By using the kits you automatically get any updates made by the Carbon for IBM.com team so you don’t
 need to go back and change any designs to match the latest release. And when
 handing off to your developers there won’t be confusion about the component and
 its behaviors.
@@ -63,17 +66,13 @@ IBMers can learn more about accessing design software in the
 
 </Row>
 
-#### Sketch kit
-
-For previous users of the Expressive Sketch kit, please note that this is no
-longer being maintained. We have a new [Sketch kit](designing/sketch-kit/) that includes color tokens,
-and expressive and productive type styles, and some key Carbon for IBM.com
-components. We are continuing to add more components and you will receive
-notifications for any library updates within Sketch.
-
 #### Figma kit
 
-We also have a [Figma kit](designing/figma-kit) available. The kit includes libraries for each of the themes (White, Gray 10, Gray 90, and Gray 100) and includes color tokens and expressive and productive type styles. It also includes some preliminary components and we are building out more Carbon for IBM.com components each week.
+We provide a [Figma kit](designing/figma-kit) that includes assets for the White theme which is primarily used throughout the IBM.com experience. The kit includes color tokens, the expressive and productive type styles, and select components.
+
+#### Sketch kit
+
+We have a [Sketch kit](designing/sketch-kit/) that includes color tokens, and expressive and productive type styles, and some key Carbon for IBM.com components. _We are no longer maintaining the Sketch kit and recommend teams migrate to Figma._
 
 ## Learn about the foundations
 

--- a/src/pages/designing/index.mdx
+++ b/src/pages/designing/index.mdx
@@ -15,7 +15,7 @@ started designing web pages for IBM.com.
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>
-<AnchorLink>Install the design kits</AnchorLink>
+<AnchorLink>Install the design kit</AnchorLink>
 <AnchorLink>Learn about the foundations</AnchorLink>
 <AnchorLink>Designing with Carbon for IBM.com</AnchorLink>
 <AnchorLink>Watch our tutorials</AnchorLink>
@@ -29,7 +29,7 @@ Whether you're just getting started designing at IBM or you've been here a while
 
 Carbon for IBM.com is just one part of the IBM ecosystem and you may have to go to different sites to find what you're looking for. We'll show you the way.
 
-## Install the design kits
+## Install the design kit
 
 <Row>
 <Column  colLg={8} colMd={8} colSm={4}>

--- a/src/pages/designing/sketch-kit.mdx
+++ b/src/pages/designing/sketch-kit.mdx
@@ -10,6 +10,12 @@ description:
 With the Carbon for IBM.com Sketch resources, you have everything you need to
 get started designing web pages for IBM.com.
 
+<InlineNotification>
+
+**We no longer maintain or update Sketch libraries.** The instructions and resources listed below may be outdated. We recommend you migrate to Figma to get the most updated kits we offer.
+
+</InlineNotification>
+
 </PageDescription>
 
 <AnchorLinks>

--- a/src/pages/designing/sketch-kit.mdx
+++ b/src/pages/designing/sketch-kit.mdx
@@ -20,28 +20,24 @@ get started designing web pages for IBM.com.
 
 <AnchorLinks>
 
-<AnchorLink>Install the new Sketch kit</AnchorLink>
+<AnchorLink>Install the Sketch kit</AnchorLink>
 <AnchorLink>Get Carbon for IBM.com components</AnchorLink>
 <AnchorLink>Other Sketch resources</AnchorLink>
 <AnchorLink>Using the Sketch kit</AnchorLink>
 
 </AnchorLinks>
 
-## Install the new Sketch kit
+## Install the Sketch kit
 
 <Row>
 <Column  colLg={8} colMd={8} colSm={4}>
 
-We have a new Sketch kit for delivering pre-built versions of the Carbon for
+We have a Sketch kit for delivering pre-built versions of the Carbon for
 IBM.com components. It's available in each of the themes and includes color
 tokens, expressive and productive type styles, and components.
 
-We'll be adding more components over time, and Sketch will notify you when
-library updates are available.
-
 For previous users of our Carbon Expressive Sketch kit, please note it is no
-longer being maintained. Our focus is on our new kits and making these design
-assets available for adopters as soon as possible.
+longer being maintained.
 
 </Column>
 


### PR DESCRIPTION
### Related Ticket(s)

#1517 

### Description

Added notice that we are no longer supporting Sketch kit to Get started and Sketch kit pages

### Changelog

Sketch kit page
- added notification
- removed "new" from "new Sketch" kit

Get started page
- Removed mention of the "expressive kit"
- Moved Figma kit to first position
- Added mention that we are no longer supporting the sketch kit to intro paragraph under the Install the design kits and Sketch kit paragraphs
- Removed mention of other themes in Figma kit
- Removed mention of adding new components each week
