### PR TITLE
updates to help overview page

### DIFF
--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -5,27 +5,27 @@ description: The help page for Carbon for IBM.com
 
 <PageDescription>
 
-The Carbon for IBM.com core team provides support for users of the design system. Find the use case below that most closely matches your own for the quickest response.
+Have a question about our design system? The Carbon for IBM.com team is here to help you. Before you start, be sure to check out the following resources to see if we’ve already got your topic covered.
 
 </PageDescription>
 
 <AnchorLinks>
 
-<AnchorLink>Questions</AnchorLink>
+<AnchorLink>Check existing resources</AnchorLink>
 <AnchorLink>Suggestions or contributions</AnchorLink>
 <AnchorLink>Resources</AnchorLink>
 
 </AnchorLinks>
 
-## Questions
+## Check existing resources
 
 ### Carbon for IBM.com website
 
-Please take some time to explore the content on this website before engaging the Carbon for IBM.com core team. The site is very comprehensive and most of the guidelines and components are well documented.
+Please take some time to explore the content on this website before engaging the Carbon for IBM.com team. The site is very comprehensive and most of the guidelines and components are well documented.
 
 ### Frequently asked questions
 
-Answers to the most common questions about the design system can be found in the [FAQ](/help/faqs).
+Answers to the most common questions about the design system can be found in the [FAQs](/help/faqs).
 
 ### Slack channels
 
@@ -34,7 +34,7 @@ _Internal IBM users only. The Carbon for IBM.com core team maintains the followi
 - [#carbon-for-ibm-dotcom](https://ibm-studios.slack.com/archives/C2PLX8GQ6)
 - [#carbon-web-components](https://ibm-studios.slack.com/archives/CL83LMKSA)
 
-**Please try searching the Slack channel for your topic first.** Slack’s filtering feature will return more targeted and relevant results. For instance, if you have a technical question about the DataTable component, you could search “DataTable” in Slack and then filter by the #carbon-for-ibm-dotcom channel.
+**Please try searching the Slack channel for your topic first.** Slack’s filtering feature will return more targeted and relevant results. For instance, if you have a technical question about the Table of contents component, you could search “Table of contents” in Slack and then filter by the #carbon-for-ibm-dotcom channel.
 
 _Tip: You can start a new search directly from the message box using the /s slash command._
 
@@ -44,14 +44,10 @@ _Internal IBM users only._
 
 Need help using the design system? Come to the Carbon for IBM.com weekly office hours! Feel free to join just to listen, or sign up ahead of the time with projects to discuss.
 
-- [Design office hours](https://ec.yourlearning.ibm.com/w3/event/10289722)
-- [Development office hours](https://ec.yourlearning.ibm.com/w3/event/10289727)
+- [Design office hours](https://ec.yourlearning.ibm.com/w3/event/10323408)
+- [Development office hours](https://ec.yourlearning.ibm.com/w3/event/10373248)
 
 ## Suggestions or contributions
-
-### GitHub pull requests
-
-If you have a specific fix or contribution, you can generate a pull request in the appropriate Carbon for IBM.com repo.
 
 ### GitHub issues
 
@@ -71,27 +67,19 @@ Bug reports, feature requests, and general feedback can be delivered to the Carb
 
 - [Bugs/Feature Requests](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose)
 
+### GitHub pull requests
+
+If you have a specific fix or contribution, you can generate a pull request in the appropriate Carbon for IBM.com repo.
+
 ## Resources
 
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="For coding and designing questions: #carbon-for-ibm-dotcom"
-      aspectRatio="2:1"
-      actionIcon="launch"
-      href="https://ibm-studios.slack.com/archives/C2PLX8GQ6"
-      >
-
-![Slack icon](../../images/icon/slack-mark.svg)
-
-  </ResourceCard>
-</Column>
-<Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
       subTitle="Design Office Hours"
       aspectRatio="2:1"
       actionIcon="launch"
-      href="https://ec.yourlearning.ibm.com/w3/event/10289722"
+      href="https://ec.yourlearning.ibm.com/w3/event/10323408"
       >
 
 ![Slack icon](../../images/icon/bee_icon.svg)
@@ -103,10 +91,22 @@ Bug reports, feature requests, and general feedback can be delivered to the Carb
       subTitle="Development Office Hours"
       aspectRatio="2:1"
       actionIcon="launch"
-      href="https://ec.yourlearning.ibm.com/w3/event/10289727"
+      href="https://ec.yourlearning.ibm.com/w3/event/10373248"
       >
 
 ![Slack icon](../../images/icon/bee_icon.svg)
+
+  </ResourceCard>
+</Column>
+<Column colMd={4} colLg={4} noGutterSm>
+    <ResourceCard
+      subTitle="For coding and designing questions: #carbon-for-ibm-dotcom"
+      aspectRatio="2:1"
+      actionIcon="launch"
+      href="https://ibm-studios.slack.com/archives/C2PLX8GQ6"
+      >
+
+![Slack icon](../../images/icon/slack-mark.svg)
 
   </ResourceCard>
 </Column>

--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -11,13 +11,13 @@ Have a question about our design system? The Carbon for IBM.com team is here to 
 
 <AnchorLinks>
 
-<AnchorLink>Check existing resources</AnchorLink>
+<AnchorLink>Questions</AnchorLink>
 <AnchorLink>Suggestions or contributions</AnchorLink>
 <AnchorLink>Resources</AnchorLink>
 
 </AnchorLinks>
 
-## Check existing resources
+## Questions
 
 ### Carbon for IBM.com website
 


### PR DESCRIPTION
### Related Ticket(s)

#1517 
### Description

Updates to overview help page

### Changelog

**New**

- updated office hour links (outdated!)
- Open to removing "Resources" section all together because it's duplicate information from further up on the page
