### PR TITLE
update faq page

### DIFF
--- a/src/pages/help/faqs.mdx
+++ b/src/pages/help/faqs.mdx
@@ -5,7 +5,7 @@ description: What is Carbon for IBM.com? Who works on Carbon for IBM.com? How ca
 
 <PageDescription>
 
-Below are some of the most frequently asked Carbon for IBM.com questions. If there is a question not answered below, please don't hesitate to [contact us](https://cognitive-app.slack.com/archives/C2PLX8GQ6).
+Below are some of the most frequently asked questions about Carbon for IBM.com. If there is a question not answered below, please don't hesitate to [contact us](https://cognitive-app.slack.com/archives/C2PLX8GQ6).
 
 </PageDescription>
 
@@ -17,17 +17,13 @@ Carbon for IBM.com is a resource for the community of designers and developers i
 
 Carbon Design System aka [Carbon](https://www.carbondesignsystem.com) is how the IBM Design Language is implemented across IBM products. Choosing Carbon as the strategic solution for Carbon for IBM.com ensures IBM has one consolidate design system across product and web. Carbon for IBM.com works alongside Carbon to produce components, patterns and guidelines to leverage IDL for IBM.com’s more expressive nature.
 
-### What happened to Duo?
-
-“Duo” was the codename for the redesign and revamp of the IBM Design Ethos and Language. This effort is still being carried out today throughout all of IBM Design. The new IBM Design Ethos and Language is directly influencing the evolution of Carbon for IBM.com.
-
 ### Is Carbon for IBM.com ready to use?
 
-Yes! You can reach out to our team at [#carbon-for-ibm-dotcom](https://ibm-studios.slack.com/archives/C2PLX8GQ6) with any questions. We also have [design](https://ec.yourlearning.ibm.com/w3/event/10289722) and [development](https://ec.yourlearning.ibm.com/w3/event/10289727) office hours.
+Yes! You can reach out to our team at [#carbon-for-ibm-dotcom](https://ibm-studios.slack.com/archives/C2PLX8GQ6) with any questions. We also have weekly [design](https://ec.yourlearning.ibm.com/w3/event/10323408) and [development](https://ec.yourlearning.ibm.com/w3/event/10373248) office hours for live support.
 
 ### When will v18 (Northstar) be sunset?
 
-Northstar is in steady state now. This means no new enhancements and will only be updated for security patches. It will remain in place through 2022 with limited support but adopters are encouraged to make plans to migrate to Carbon for IBM.com as soon as possible. In 2019, it was announced that Carbon is the overall strategic direction for IBM web and product experiences.
+Northstar is in maintenance. This means no new enhancements and will only be updated for security patches. It will remain in place through 2023 with limited support but adopters are encouraged to make plans to migrate to Carbon for IBM.com as soon as possible. In 2019, it was announced that Carbon is the overall strategic direction for IBM web and product experiences.
 
 ### Is there anything not available in Carbon for IBM.com?
 
@@ -35,20 +31,18 @@ In order to stay current with what’s coming, read the [Release Schedule](https
 
 ### Where can I get current information?
 
-- For information on the rollout schedule, see the [Roadmap](https://app.zenhub.com/workspaces/carbon-for-ibmcom-5d449f3642eb1962336cbe52/roadmap?invite=true) on our Zenhub board.
 - For announcements, join the [#carbon-for-ibm-dotcom](https://ibm-studios.slack.com/archives/C2PLX8GQ6) Slack channel.
 - For design guidelines, see the [Designing](https://www.ibm.com/standards/carbon/designing) page.
 - For coding guidelines, see the [Developing](https://www.ibm.com/standards/carbon/developing) page.
-- For guidance regarding overall expression, review the [IBM Design Language](https://www.ibm.com/design/language/).
 
 ### How can I contribute and/or propose new components/ideas?
 
-Please open an [issue](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose) under **"Feature Request"** and include as much detail as possible in the issue to ensure we understand the context and desire for this proposal. We will prioritize these based on feasibility and user impact. Additional contribution guidelines are coming soon.
+Please open an [issue](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose) under **"Feature Request"** and include as much detail as possible in the issue to ensure we understand the context and desire for this proposal. We will prioritize these based on feasibility and user impact.
 
 ### I found a bug. How do I report it?
 
 Please open an [issue](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose) under **"Bug Report"** in our GitHub repo. We will evaluate the bug in our weekly triage meeting. If you have a fix for the bug, please feel free to submit a PR for it in the GitHub repository.
 
-### Where do I go if I’ve read everything and still have an issue/question?
+### Where do I go if I’ve read everything and still have an issue or question?
 
 Ask on the [#carbon-for-ibm-dotcom](https://cognitive-app.slack.com/archives/C2PLX8GQ6) Slack channel or open an [issue](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new/choose) under **"Question"** in our GitHub repo.


### PR DESCRIPTION
### Related Ticket(s)

#1517 

### Description

Updates to FAQ

### Changelog

- Removed "What happened to Duo?" – over four years old this is extremely outdated
- Update links to office hours
- Updated v18 section: ~steady state~ to "maintenance" and ~2022~ to 2023
- Removed link to Roadmap and IDL under Where can I get current info
   - We don't maintain the Roadmap in Zenhub
   - IDL doesn't feel quite right in this context
- Removed "Additional details coming soon" from How can I contribute section.