### PR TITLE
remove gif, slight reorganization

### DIFF
--- a/src/pages/components/cards.mdx
+++ b/src/pages/components/cards.mdx
@@ -130,7 +130,7 @@ Cards with pictograms offer two pictogram positions: top-aligned or bottom-align
 
 <InlineNotification>
 
-**Alignment:** We highly recommend using the bottom-aligned layout to achieve consistency with the updated [Carbon tile guidance](https://carbondesignsystem.com/components/tile/usage/).
+**Alignment:** We highly recommend using the bottom-aligned layout to achieve consistency with the updated [Carbon tile guidance](https://carbondesignsystem.com/components/tile/usage/). In Carbon for IBM.com v2, all content in the card pictogram will be visible from the enabled state – there will be no hover reveal.
 
 </InlineNotification>
 
@@ -148,21 +148,7 @@ Cards with pictograms offer two pictogram positions: top-aligned or bottom-align
 </Row>
 
 Bottom-aligning the pictogram ensures that the card heading is the first element the user reads. This helps when the
-message is not immediately decipherable from the pictogram.
-
-An added bonus for the bottom-aligned pictogram is the feature of showing copy on hover.
-
-<Row>
-<Column colMd={8} colLg={8}>
-
-![Image of Card component](../../images/component/card/card-pictogram-motion.gif)
-
-<Caption>
-  Example of copy being shown on hover with bottom-aligned pictogram
-</Caption>
-
-</Column>
-</Row>
+message is not immediately decipherable from the pictogram. An added bonus for the bottom-aligned pictogram is the feature of showing copy on hover.
 
 Top-aligning the pictogram should only be used when the pictogram is strongly and precisely associated with the card
 heading. For example, an airplane is the perfect choice for "Aerospace and defence", as shown in the above example.


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

The gif in the `card – pictogram` section is wrong according to the specs and build. The heading and body copy are swapped on hover, not the pictogram as the gif suggests.

### Changelog

**New**

- N/A

**Changed**

- Minor reorganization in the `card – pictogram` section.

**Removed**

- gif under pictogram modifier section.
