### PR TITLE
update--whats-happening-page-v2

### DIFF
--- a/src/pages/whats-happening/index.mdx
+++ b/src/pages/whats-happening/index.mdx
@@ -1,21 +1,21 @@
 ---
 title: What’s happening
-description: We are excited to announce the upcoming release of Carbon for IBM.com v2! This update focuses on upgrading to Carbon v11, improving the layout experience for ease of authoring as well as other component improvements for designers and developers.
+description: We are excited to announce the release of Carbon for IBM.com v2! This update focuses on upgrading to Carbon v11, improving the layout experience for ease of authoring as well as other component improvements for designers and developers.
 ---
 
 <PageDescription>
 
-We are excited to announce the upcoming release of **Carbon for IBM.com v2**! This update focuses on upgrading to Carbon v11, improving the layout experience for ease of authoring as well as other component improvements for designers and developers.
+We are excited to announce the release of **Carbon for IBM.com v2**! This update focuses on upgrading to Carbon v11, improving the layout experience for ease of authoring as well as other component improvements for designers and developers.
 
 </PageDescription>
 
 ## Overview
 
-As with a major release, there will be some breaking changes that will require minor redesigning and/or content adjustments. The Design Program Office team will provide design and development guidance to help facilitate the migration to v2.
+As with a major release, there will be some breaking changes that will require minor redesigning and/or content adjustments. The Carbon for IBM.com team will provide design and development guidance to help facilitate the migration to v2.
 
 ### Information sessions
 
-Watch the Carbon for IBM.com team showcase the updates coming in Carbon for IBM.com v2. _Note that information session content is accessible to IBMers only._
+Watch the Carbon for IBM.com team showcase the updates in Carbon for IBM.com v2. _Note that information session content is accessible to IBMers only._
 
 | Session date | Recording | Slides |
 | -------- | -------- | -------- |
@@ -29,7 +29,7 @@ Watch the Carbon for IBM.com team showcase the updates coming in Carbon for IBM.
 - Faster page load times
 - Web Components upgraded to use Lit v2
 - Simplified component list with more flexibility for each component
-- Component enhancements for authoring such as content section and Masthead v2
+- Component enhancements for authoring such as content section, content block, and Masthead v2
 - Improvements to spacing logic across Carbon for IBM.com's Layout and UI components
 - Accessibility improvements for components
 
@@ -41,17 +41,13 @@ Visit our Github for a table version of our [long-term support schedule](https:/
 
 ## FAQ
 
-#### What is the Carbon for IBM.com v2 beta and when will it be ready?
+#### When will Carbon for IBM.com v2 be ready for production?
 
-Beta version of v2 is planned for end of June 2023. This will be the first pre-release version of the library. It will be the first opportunity for adopters/users to work with the package and provide feedback to the team regarding any bugs or differences that weren’t expected. See the Long-term Support timeline above.
-
-#### When are we launching Carbon for IBM.com v2 production?
-
-Production release is planned for end of November 2023. This will be when the package is considered General Availability (GA). See the Long-term Support timeline above.
+Carbon for IBM.com was release on December 11, 2023 and is ready to be used in production environments!
 
 #### What is required for migration?
 
-We are working on migration guidance as we build out the v2 package. More resources and links will be provided here, so check back for more details.
+We have done our best to minimize migration efforts for our adopters. Please see our [migration docs](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/blob/release/v2.0.0/docs/dotcom-v2-migration.md) for more details.
 
 #### When do adopters have to migrate?
 
@@ -64,11 +60,9 @@ Carbon for IBM.com v2 will no longer support React and focus fully on web compon
 ## Questions?
 
 We're here to answer any questions!
-[Reach out to us](https://cognitive-app.slack.com/archives/C2PLX8GQ6) via Slack
-or join our weekly Office Hours.
+Reach out to us via [GitHub](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/new?assignees=&labels=question&projects=&template=question.yaml&title=%5BYOUR+TITLE%5D%3A+Brief+description) or [Slack](https://cognitive-app.slack.com/archives/C2PLX8GQ6) 
 
-- Developers meet Wednesdays at 9am ET.
-- Designers meet Wednesdays at 10am ET.
+IBMers can join our Office Hours:
 
-Details are posted in our
-[Slack channel](https://cognitive-app.slack.com/archives/C2PLX8GQ6).
+- [Developers](https://ibm.box.com/s/894z9uk7qyhdl65s3tjs0xnim3mb1b17)
+- [Designers](https://ec.yourlearning.ibm.com/w3/event/10323408)


### PR DESCRIPTION
### Related Ticket(s)

#1647 

### Description

Update the what's happening page in v2 website

### Changelog


**Changed**

- Removed "launching" past tense phrasing 
- Added link to migration docs
- Questions section reframed slightly for evergreen content 
   - removed "weekly" and exact dates and times for office hours


