### PR TITLE
fix--about-page--web-components-link

### DIFF
--- a/src/pages/about-carbon-for-ibm.com/about.mdx
+++ b/src/pages/about-carbon-for-ibm.com/about.mdx
@@ -25,7 +25,7 @@ Carbon for IBM.com is for IBM teams building web experiences for the IBM.com sit
 
 The system is developed and maintained by the Digital Design Squad—a core team of designers, developers, and writers.
 
-Carbon for IBM.com components are built with [Web Components](https://www.ibm.com/standards/carbon/web-components/?path=/story/overview-getting-started--page).
+Carbon for IBM.com components are built with [Web Components](https://www.ibm.com/standards/carbon/web-components/).
 
 ## Our place in the ecosystem
 


### PR DESCRIPTION
### Related Ticket(s)

N/A 

An adopter noticed the link to Web Components was broken on the About page and they were getting a 404 message. See [slack](https://ibm-studios.slack.com/archives/C2PLX8GQ6/p1702916113871939)

