### PR TITLE
docs(storybook): replace all storybook links with v1 links

### DIFF
--- a/src/data/components.json
+++ b/src/data/components.json
@@ -5,8 +5,8 @@
       "designLink": "https://ibm.box.com/s/1ol1qe0tdplhet6mh9z2sx5ncqmikd4r",
       "description": "Back to top is a sticky button that appears on long form pages. When triggered it scrolls the the user back to the top of the page.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-back-to-top--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-back-to-top--default"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-back-to-top--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-back-to-top--default"
       },
       "webcomponents": {
         "stable": true,
@@ -32,7 +32,7 @@
       "designLink": "https://ibm.box.com/s/unvd38oewwguycqoqg0et75eluiiqhg6",
       "description": "CTA stands for call to action. A CTA refers to the use of words or phrases that can compel an audience to act in a specific way.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-cta--text",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-cta--text",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-cta--button"
       },
       "webcomponents": {
@@ -59,9 +59,9 @@
       "designLink": "https://ibm.ent.box.com/folder/95514001950?s=qqw0soczjpawvuh9j3x19fmcoqk1zsw7",
       "description": "Cards are considered “workhorse” components because of their versatility. They provide effective calls to action, and the various designs available work with a wide range of content.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-card--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-card--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-card--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-card--default"
       },
       "webcomponents": {
         "stable": true,
@@ -87,8 +87,8 @@
       "designLink": "https://ibm.box.com/s/jad2fd65p56odcme9aoy1lgmuo1xaifu",
       "description": "Card in card offers a large media moment, while keeping harmony in a card group.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-in-card--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-card-in-card--default"
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-in-card--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-card-in-card--default"
       },
       "webcomponents": {
         "stable": true,
@@ -114,9 +114,9 @@
       "designLink": "https://ibm.box.com/s/1u2m0fqdtrumog0ie2c4tfyyyn1clyj7",
       "description": "Card link is a CTA styled like a card that acts as the main CTA for a section of content, it typically appears at the end of a block-pattern.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-link--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-link--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-card-link--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-card-link--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-card-link--default"
       },
       "webcomponents": {
         "stable": true,
@@ -142,8 +142,8 @@
       "designLink": "https://ibm.box.com/s/hmni7qhero9mf5rn593zij0tcay8h9dw",
       "description": "The carousel is an exploratory component, meaning it allows users to browse or explore multiple pieces of content within the same area of the page.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-carousel--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-carousel--default"
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-carousel--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-carousel--default"
       },
       "webcomponents": {
         "stable": true,
@@ -170,7 +170,7 @@
       "functionalLink": false,
       "description": "Dotcom shell includes the <a href=\"./masthead\">Masthead</a>, and <a href=\"./footer\">Footer</a> components, all wrapped in a UI shell using Carbon's grid.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-dotcom-shell--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-dotcom-shell--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-dotcom-shell--default"
       },
       "webcomponents": {
@@ -197,9 +197,9 @@
       "designLink": "https://ibm.box.com/s/35er5s6qfjcpcm98jafklc1alcl5vy16",
       "description": "Expressive modal is based on the Carbon modal component with slight styling updates to increase the padding and uses fixed buttons.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-expressive-modal--default",
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-expressive-modal--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-expressive-modal--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-expressive-modal--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-expressive-modal--default"
       },
       "webcomponents": {
         "stable": true,
@@ -225,9 +225,9 @@
       "designLink": "https://ibm.box.com/s/292bsxb7tat33ch341u8o4oh6xdx19ct",
       "description": "Feature card is used to emphasize a piece of information with a card on the right-hand side and an image on the left-hand side.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-feature-card--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-feature-card--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-feature-card--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-feature-card--medium"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-feature-card--medium"
       },
       "webcomponents": {
         "stable": true,
@@ -253,8 +253,8 @@
       "designLink": "https://ibm.box.com/s/19a0hjn61gh3qh59kbgxba43y8uymuqy",
       "description": "The filter panel is a component that can be customized to provide categorized filters to help users trim down large amounts of content, data and/or search results.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-filter-panel--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-filter-panel--default"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-filter-panel--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-filter-panel--default"
       },
       "webcomponents": {
         "stable": true,
@@ -280,7 +280,7 @@
       "designLink": "https://ibm.box.com/s/nsbccv6jigfw78uwq3r0242qks1x1f87",
       "description": "The Footer is required on all IBM.com pages, it is placed at the bottom of a page and acts as the catch-all section that helps users navigate and provides corporate level general and legal information.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-footer--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-footer--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-footer--default"
       },
       "webcomponents": {
@@ -307,7 +307,7 @@
       "designLink": "https://ibm.box.com/s/ladjc15eyxg61c5wqbshggm3e4zgrnp5",
       "description": "The horizontal rule component is utilized for thematic breaks within the content.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-horizontal-rule--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-horizontal-rule--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-horizontal-rule--default"
       },
       "webcomponents": {
@@ -334,9 +334,9 @@
       "designLink": "https://ibm.box.com/s/zaofzs8ssrfbkgker2lqxyvdnbpxvsly",
       "description": "The Image and the Image with caption components offer two ways to display imagery on the page.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-image--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-image--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-image--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-image--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-image--default"
       },
       "webcomponents": {
         "stable": true,
@@ -362,7 +362,7 @@
       "designLink": "https://ibm.box.com/s/mclmewshqcme7g6gykepok78rm882a0j",
       "description": "The Image with caption component is used to embed images and has an optional caption. It can support images at 1x1, 2x1, 4x3 and 16x9 aspect ratios.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-image-with-caption--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-image-with-caption--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-imagewithcaption--default"
       },
       "webcomponents": {
@@ -390,7 +390,7 @@
       "functionalLink": false,
       "description": "Language selector is for users to select their preferred language on a website. The content on the website will appear in the default language until the users reselect their preferred language then the page content will reload in the reselected language provided a translation is available.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-footer--default-language-only",
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-footer--default-language-only",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-footer--default-language-only"
       },
       "webcomponents": {
@@ -418,8 +418,8 @@
       "functionalLink": "https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Leaving-ibm",
       "description": "The Leaving IBM notice displays as an overlay when a user clicks an external link.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-leaving-ibm--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-leaving-ibm--default"
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-leaving-ibm--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-leaving-ibm--default"
       },
       "webcomponents": {
         "stable": true,
@@ -445,7 +445,7 @@
       "designLink": "https://ibm.box.com/s/mpeo1wy0jogkwxn68fahlg62q799ixox",
       "description": "Lightbox media viewer allows the user to view an image or video at a larger size within a modal.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-lightbox-media-viewer--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-lightbox-media-viewer--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-lightbox-media-viewer--default"
       },
       "webcomponents": {
@@ -472,7 +472,7 @@
       "designLink": "https://ibm.box.com/s/dgnfrnpaqepbuyifa04aoc091v4cnz3d",
       "description": "Link list is used for multiple CTAs, with options for vertical and horizontal lists and varying CTA styling.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-link-list--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-link-list--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-link-list--default"
       },
       "webcomponents": {
@@ -499,7 +499,7 @@
       "designLink": "https://ibm.box.com/s/mktywz4ujxo9yiiu371kgzbib93uc2po",
       "description": "Link list section is used for multiple CTAs, with options for vertical and horizontal lists and varying CTA styling.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-link-list-section--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-link-list-section--default",
         "react": ""
       },
       "webcomponents": {
@@ -526,7 +526,7 @@
       "designLink": "https://ibm.box.com/s/i3jd6saoz0m851j2ohggrn452bnd51dm",
       "description": "Link with icon is primarily used as a navigational element with an icon as an indicator to the destination or type of content being referenced. Link with icon should not be used within a paragraph.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-link-with-icon--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-link-with-icon--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-link-with-icon--default"
       },
       "webcomponents": {
@@ -553,7 +553,7 @@
       "designLink": "https://ibm.box.com/s/nwy0fyiw6mu3qwd3p882pnqmit93rfa5",
       "description": "Locale modal is triggered after selecting the locale button and allows users to change geographic regions and languages, if available.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-locale-modal--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-locale-modal--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-locale-modal--default"
       },
       "webcomponents": {
@@ -580,9 +580,9 @@
       "designLink": "https://ibm.box.com/s/knez30xt6kao1amylebbvs97vkemhrbp",
       "description": "Masthead is a fundamental navigational component for IBM.com that displays consistently at the top of each page. It also includes search and profile services for IBM.com.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-masthead--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-masthead--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-masthead--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-masthead--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-masthead--default"
       },
       "webcomponents": {
         "stable": true,
@@ -608,9 +608,9 @@
       "designLink": "https://ibm.box.com/s/0hjsr1foe5y849xs6ixc5g25uf9lgjr6",
       "description": "Quote is used to highlight an impactful client statement or user testimonial.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-quote--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-quote--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-quote--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-quote--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-quote--default"
       },
       "webcomponents": {
         "stable": true,
@@ -636,8 +636,8 @@
       "designLink": "https://ibm.box.com/s/26zrugvym00408zhpp23gqwnudzmgdd1",
       "description": "Tabs extended combines tabs and accordion to organize editorial content.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-tabs-extended--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-tabs-extended--default"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-tabs-extended--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-tabs-extended--default"
       },
       "webcomponents": {
         "stable": true,
@@ -662,8 +662,8 @@
       "url": "/components/tags",
       "description": "Tags help label and categorize content using keywords. Tag link enables a tag to be clickable and navigate users to related content.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-tag-link--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-tag-link--default"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-tag-link--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-tag-link--default"
       },
       "webcomponents": {
         "stable": true,
@@ -689,8 +689,8 @@
       "designLink": "https://ibm.box.com/s/y5dx0hxzcsn6i6xv6i1vwlsec300gbm5",
       "description": "Tag link enables a tag to be clickable and navigate users to related content.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-tag-link--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-tag-link--default"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-tag-link--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-tag-link--default"
       },
       "webcomponents": {
         "stable": true,
@@ -716,8 +716,8 @@
       "designLink": "https://ibm.box.com/s/t2njzzny00mgy67cxj0r420nacvpvc83",
       "description": "Tag link enables a tag to be clickable and navigate users to related content.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-tag-group",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-tag-group"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-tag-group",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-tag-group"
       },
       "webcomponents": {
         "stable": true,
@@ -743,9 +743,9 @@
       "designLink": "https://ibm.box.com/s/9q7rdj73m32hufcw1xwl1td6nr88rghm",
       "description": "Video allows you to embed Kaltura videos from the media center in various ways throughout a page.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-video-player--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-video-player--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-video-player--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-video-player--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-video-player--default"
       },
       "webcomponents": {
         "stable": true,
@@ -773,9 +773,9 @@
       "designLink": "https://ibm.box.com/s/5p4zb97inftv5bj6dabgk8cpp9fbdr4w",
       "description": "Callout quote is a typographic layout that is used to highlight an impactful client statement or user testimonial.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-callout-quote--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-callout-quote--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-callout-quote--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-callout-quote--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-callout-quote--default"
       },
       "webcomponents": {
         "stable": true,
@@ -802,9 +802,9 @@
       "functionalLink": "https://github.com/carbon-design-system/carbon-for-ibm-dotcom-website/wiki/Callout-media",
       "description": "Callout with media is used to feature a high value media asset such as a customer story.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-callout-with-media--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-callout-with-media--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-callout-with-media--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-callout-with-media--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-callout-with-media--default"
       },
       "webcomponents": {
         "stable": true,
@@ -830,9 +830,9 @@
       "designLink": "https://ibm.box.com/s/r4nt1w1fe2gnuqn6m9gac48tll7jq5pl",
       "description": "Card group arranges cards in a grid and offers useful features that are applied to the group as a whole.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-group--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-group--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-card-group--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-card-group--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-card-group--default"
       },
       "webcomponents": {
         "stable": true,
@@ -858,7 +858,7 @@
       "designLink": "https://ibm.box.com/s/6prfrgt7dftdg47ejy3q3m4x7h47kbmo",
       "description": "Card section is a collection of cards presented in a full-width section with a left-column header that responds to the grid.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-section-simple--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-section-simple--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-card-section-simple--default"
       },
       "webcomponents": {
@@ -885,8 +885,8 @@
       "designLink": "https://ibm.box.com/s/wyj5uboppri7nc3gn4v1f7ft80qc5eir",
       "description": "Card section carousel is an exploratory component, meaning it allows users to browse or explore multiple pieces of content within the same area of the page.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-section-carousel--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-card-section-carousel--default"
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-section-carousel--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-card-section-carousel--default"
       },
       "webcomponents": {
         "stable": true,
@@ -912,7 +912,7 @@
       "designLink": "https://ibm.box.com/s/u4acyo9oeqya8xidimxtidh8k8y08fza",
       "description": "Card section images is a collection of card components with images that, together, occupy a full-width section with a left-column header.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-section-images--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-section-images--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-card-section-images--default"
       },
       "webcomponents": {
@@ -939,9 +939,9 @@
       "designLink": "https://ibm.box.com/s/uaq0ovswviefwbv7gd4jn13llvqb23f8",
       "description": "Content block is a high-level layout component that acts as the main content unit used inside of a Content section to build web experiences on IBM dotcom. It encapsulates other content components (one or multiple content groups) and brings them together into a custom visual, which solves a specific problem for the user.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-block--default",
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-block--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-content-block--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-content-block--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-content-block--default"
       },
       "webcomponents": {
         "stable": true,
@@ -967,7 +967,7 @@
       "designLink": "https://ibm.box.com/s/9pweudf9ptucx8jxzgo3e2m5jpyke5qi",
       "description": "Content block cards is used to present small self-contained pieces of information as cards.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-block-cards--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-block-cards--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-content-block-cards--default"
       },
       "webcomponents": {
@@ -994,9 +994,9 @@
       "designLink": "https://ibm.box.com/s/rv5kmm0a4d9ded74v6yfk8ad5id5ghmx",
       "description": "Content block horizontal is used to highlight a group of more important pieces of content, such as products or solutions, with more visual weight.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-block-horizontal--default",
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-block-horizontal--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-content-block-horizontal--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-content-block-horizontal--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-content-block-horizontal--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1022,9 +1022,9 @@
       "designLink": "https://ibm.box.com/s/9cu22l7vs1dpjy8g8yi3mtoswazqgq2r",
       "description": "Content block media is used to present information with images in a group setting.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-block-media--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-block-media--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-content-block-media--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-content-block-media--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-content-block-media--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1050,7 +1050,7 @@
       "designLink": "https://ibm.box.com/s/pkascpokk7ae4t3ixis98hmw4e5y1v56",
       "description": "Content block segmented is a variation of Content block simple with the added ability to add subsections.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-block-segmented--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-block-segmented--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-content-block-segmented--default"
       },
       "webcomponents": {
@@ -1077,9 +1077,9 @@
       "designLink": "https://ibm.box.com/s/511cy3utuof76on064vfzmv8dej5nc8c",
       "description": "Content block simple is typically used for the introductory section on a page.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-block-simple--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-block-simple--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-content-block-simple--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-content-block-simple--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-content-block-simple--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1105,9 +1105,9 @@
       "designLink": "https://ibm.box.com/s/5n0sj6b3kkicnwimxmgnwb5owm46g8wz",
       "description": "Content group acts as a content unit, and is used inside a Content section or a Content block. It can contain basic content components (one or multiple content items of the same kind), bringing them together into highly-customized solutions for the user.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-group--default",
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-group--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-content-group--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-content-group--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-content-group--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1133,8 +1133,8 @@
       "designLink": "https://ibm.box.com/s/tqp7c0wm99ha0b7jrm0sqhq3whwdjv84",
       "description": "Content group banner is designed as a subtle callout, intended for tangential information or announcements that are supplementary to the page's main focus.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-group-banner--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-content-group-banner--default"
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-group-banner--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-content-group-banner--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1160,7 +1160,7 @@
       "designLink": "https://ibm.box.com/s/5sfef66ow9ruw47qye5snhnxey0ioi6t",
       "description": "Content group cards is used to present information through a group of cards with each acting as a call to action that drives to additional or supporting destinations. It is suitable for adding concise buckets of content and links to a long-form reading experience.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-group-cards--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-group-cards--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-content-group-cards--default"
       },
       "webcomponents": {
@@ -1187,7 +1187,7 @@
       "designLink": "https://ibm.box.com/s/af11r4k5fv1wclv1yrl9aic5c68x29ra",
       "description": "Content group pictograms is used to present a group of information, each with a supporting pictogram.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-group-pictograms--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-group-pictograms--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-content-group-pictograms--default"
       },
       "webcomponents": {
@@ -1214,7 +1214,7 @@
       "designLink": "https://ibm.box.com/s/bkqyb6nzix46vfsy8b0cyg79c3fs0lac",
       "description": "Content group simple is an alternative form of a narrative layout where the content is broken up into smaller pieces to make it more digestible.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-group-simple--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-group-simple--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-content-group-simple--default"
       },
       "webcomponents": {
@@ -1241,9 +1241,9 @@
       "designLink": "https://ibm.box.com/s/xfm17x7dwbe4z7kjk482b8hbpjasft7o",
       "description": "The Content item is a basic-level content component that acts as a primary content unit, and it is used inside a Content group to build web experiences on IBM dotcom pages. It can encapsulate basic content (a heading, a description, a media element – image or video – and a CTA) and brings them all together into a content component which solves a specific problem for the user.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-item--default",
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-item--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-content-item--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-content-item--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-content-item--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1269,9 +1269,9 @@
       "designLink": "https://ibm.box.com/s/yiv7f37ktudwx1do7d9mp4bak17wl4dh",
       "description": "Content item horizontal component displays information in a horizontal orientation.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-item-horizontal--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-item-horizontal--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-content-item-horizontal--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-content-item-horizontal--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-content-item-horizontal--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1297,9 +1297,9 @@
       "designLink": "https://ibm.box.com/s/oqlsa6m0vfownbn1s2y682mnugsf6cuv",
       "description": "Content section is a high-level content component that acts as the main content unit to build web page experiences for IBM.com. It encapsulates other content components (one or multiple Content blocks and/or Content groups) and brings them together, providing flexibility to create many different solutions for users.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-section--default",
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-section--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-content-section--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-content-section--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-content-section--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1325,7 +1325,7 @@
       "designLink": "https://ibm.ent.box.com/folder/132927464120?s=1mbmay093kclwwjhuhmux0kqzptvpgj3",
       "description": "CTA block and section are used to communicate actions that users can take along with some information that is relevant to the actions.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-cta-block--default",
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-cta-block--default",
         "react": ""
       },
       "webcomponents": {
@@ -1352,8 +1352,8 @@
       "designLink": "https://ibm.box.com/s/yz1uixuxjf7lge5yvrup3yb3owj70071",
       "description": "CTA section is used to communicate actions that users can take along with some information that is relevant to the actions.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-cta-section--simple",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-cta-section--simple"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-cta-section--simple",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-cta-section--simple"
       },
       "webcomponents": {
         "stable": true,
@@ -1379,8 +1379,8 @@
       "designLink": "https://ibm.box.com/s/pffea4dd5aug4m3v6za7ewjd1metosg8",
       "description": "Feature section is a dedicated section for a single story.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-feature-section--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-feature-section--default"
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-feature-section--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-feature-section--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1406,7 +1406,7 @@
       "designLink": false,
       "description": "The layout component is to be utilized within IBM.com for various abstract layout configurations.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-layout--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-layout--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-layout--default"
       },
       "webcomponents": {
@@ -1433,9 +1433,9 @@
       "designLink": "https://ibm.box.com/s/d9jey3rlfxqmxu059f0x9dtcx7f5ehuh",
       "description": "Lead space sets the context and also helps users understand what type of content they are going to find on the page. It is always positioned at the top.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-lead-space--super",
-        "react": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-leadspace--tall",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-leadspace--tall"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-lead-space--super",
+        "react": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-leadspace--tall",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-leadspace--tall"
       },
       "webcomponents": {
         "stable": true,
@@ -1461,9 +1461,9 @@
       "designLink": "https://ibm.box.com/s/kisml8o6mgrexlvqaa3cv20z1e32sbli",
       "description": "Lead space block is an alternative to the Lead space, enabling a more streamlined introduction to the page. Lead space block is positioned at the top of a web page to orient the user when they land on a page, inform them of the content, and guide them to the first key piece of content on the page.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-lead-space-block--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-lead-space-block--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-lead-space-block--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-lead-space-block--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-lead-space-block--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1489,8 +1489,8 @@
       "designLink": "https://ibm.box.com/s/3rjh19oclo961z0q0oaoqtm4gbhzo8b8",
       "description": "Lead space search provides a fast route to information discovery by including a prominent search option in the lead space. As the search is always positioned at the top, it is discoverable by users the moment they land on the page.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-lead-space-search--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-lead-space-search--default"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-lead-space-search--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-lead-space-search--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1516,9 +1516,9 @@
       "designLink": "https://ibm.box.com/s/2c2dt2fivbmbcce29oul7hjaktjaqj26",
       "description": "Logo grid is used to present a group of client or partner logos. Currently the logos are not clickable.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-logo-grid--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-logo-grid--default",
         "react": "http://www.ibm.com/standards/carbon/react/?path=/story/components-logo-grid--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-logo-grid--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-logo-grid--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1544,9 +1544,9 @@
       "designLink": "https://ibm.box.com/s/kjio8inhxhkmf7245l2wccp8zsivka9l",
       "description": "Pictogram item is used to communicate messages at a glance, afford interactivity, and simplify complex ideas.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-pictogram-item--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-pictogram-item--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-pictogram-item--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-pictogram-item--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-pictogram-item--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1572,9 +1572,9 @@
       "designLink": "https://ibm.box.com/s/yfuicifhfeaefp4rl0pp62dpeacr18ry",
       "description": "The table of contents component allows users to quickly navigate through long pages by providing jump links to different sections of the content within a single page.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-table-of-contents--default",
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-table-of-contents--default",
         "react": "https://www.ibm.com/standards/carbon/react/?path=/story/components-table-of-contents--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-table-of-contents--default"
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-table-of-contents--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1600,8 +1600,8 @@
       "designLink": "https://ibm.box.com/s/3sun8lo3gu2b4uaa4oxgpxrqit1m7t6i",
       "description": "Use this component to interactively reveal related content, or as a gateway to pages with more details.",
       "storybook": {
-        "webcomponents": "http://www.ibm.com/standards/carbon/web-components/?path=/story/components-tabs-extended-with-media--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-tabs-extended-media--default"
+        "webcomponents": "http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-tabs-extended-with-media--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-tabs-extended-media--default"
       },
       "webcomponents": {
         "stable": true,
@@ -1627,8 +1627,8 @@
       "designLink": "https://ibm.box.com/s/fas5qv5zrscudr63y85g28v0k657p83u",
       "description": "Universal banner is used exclusively to feature global and critical announcements. It is the only component that can be positioned above the masthead.",
       "storybook": {
-        "webcomponents": "https://www.ibm.com/standards/carbon/web-components/?path=/story/components-universal-banner--default",
-        "reactwrapper": "https://www.ibm.com/standards/carbon/web-components/react/?path=/story/components-universal-banner--default"
+        "webcomponents": "https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-universal-banner--default",
+        "reactwrapper": "https://www.ibm.com/standards/carbon/v1/web-components/react/?path=/story/components-universal-banner--default"
       },
       "webcomponents": {
         "stable": true,

--- a/src/pages/about-carbon-for-ibm.com/about.mdx
+++ b/src/pages/about-carbon-for-ibm.com/about.mdx
@@ -25,7 +25,7 @@ Carbon for IBM.com is for IBM teams building web experiences for the IBM.com sit
 
 The system is developed and maintained by the Digital Design Squad—a core team of designers, developers, and writers.
 
-Carbon for IBM.com components are built with [Web Components](https://www.ibm.com/standards/carbon/web-components/?path=/story/overview-getting-started--page) and [React](https://www.ibm.com/standards/carbon/react/?path=/story/overview-getting-started--page).
+Carbon for IBM.com components are built with [Web Components](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/overview-getting-started--page) and [React](https://www.ibm.com/standards/carbon/react/?path=/story/overview-getting-started--page).
 
 ## Our place in the ecosystem
 

--- a/src/pages/developing/frameworks/react-wrapper.mdx
+++ b/src/pages/developing/frameworks/react-wrapper.mdx
@@ -67,8 +67,8 @@ setup which includes both React and React wrapper components.
 
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="Carbon for IBM.com Storybook React wrapper"
-  href="https://www.ibm.com/standards/carbon/web-components/react/"
+  subTitle="Carbon for IBM.com Storybook React wrapper v1"
+  href="https://www.ibm.com/standards/carbon/v1/web-components/react/"
   target="_blank"
 >
 

--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -64,7 +64,7 @@ and rendered directly without the need for front-end bundling. Here is an exampl
 </html>
 ```
 
-To see all available CDN links, visit the `Docs` tab for the corresponding components in [Storybook](https://www.ibm.com/standards/carbon/web-components).
+To see all available CDN links, visit the `Docs` tab for the corresponding components in [Storybook v1](https://www.ibm.com/standards/carbon/v1/web-components).
 
 ### Tag versus specific version
 
@@ -172,7 +172,7 @@ Learn more about <Link to="/developing/carbon-cdn-style-helpers">
 If you are looking to get started on a page, you can make use of the `<dds-dotcom-shell>`, which is a UI shell that
 contains the `<dds-masthead>` and the `<dds-footer>`, using Carbon's grid.
 
-View the `<dds-dotcom-shell>` in [Storybook Web Components](http://www.ibm.com/standards/carbon/web-components/?path=/story/components-dotcom-shell--default).
+View the `<dds-dotcom-shell>` in [Storybook Web Components](http://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-dotcom-shell--default).
 
 ## Available components
 
@@ -181,7 +181,7 @@ View the `<dds-dotcom-shell>` in [Storybook Web Components](http://www.ibm.com/s
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Carbon for IBM.com Storybook Web Components"
-  href="https://www.ibm.com/standards/carbon/web-components/"
+  href="https://www.ibm.com/standards/carbon/v1/web-components/"
   target="_blank"
 >
 
@@ -209,7 +209,7 @@ wrapper for seamless integration into a React application.
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
   subTitle="Carbon for IBM.com Storybook Web Components with React"
-  href="https://www.ibm.com/standards/carbon/web-components/react/"
+  href="https://www.ibm.com/standards/carbon/v1/web-components/react/"
   target="_blank"
 >
 

--- a/src/pages/developing/web-components-tutorial/step-1.mdx
+++ b/src/pages/developing/web-components-tutorial/step-1.mdx
@@ -276,7 +276,7 @@ In the `index.html` page, replace the previously added `button-group` with the f
 <!-- prettier-ignore-end -->
 
 You can find a description of how to further configure the `dotcom-shell` in our
-[storybook](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-dotcom-shell--default).
+[storybook](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-dotcom-shell--default).
 
 <InlineNotification>
 

--- a/src/pages/developing/web-components-tutorial/step-2.mdx
+++ b/src/pages/developing/web-components-tutorial/step-2.mdx
@@ -12,7 +12,7 @@ import { Link } from 'gatsby';
 <PageDescription>
 
 Now that we have an application using the Dotcom Shell, it’s time to include some out of the box components
-from the [Carbon for IBM.com library](https://www.ibm.com/standards/carbon/web-components/?path=/story/overview-getting-started--page)
+from the [Carbon for IBM.com library](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/overview-getting-started--page)
 in the page. In this step, we’ll become comfortable with various Carbon for IBM.com components.
 
 </PageDescription>
@@ -68,10 +68,10 @@ this step.
 
 ## Component documentation
 
-In this step, you'll be adding 4 new components to the page; [Leadspace with search](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-lead-space-search--default),
-[Table of contents - horizontal](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-table-of-contents--horizontal),
-[Card section offset](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-section-offset--default), and
-[CTA section with link list](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-cta-section--with-link-list). All components have
+In this step, you'll be adding 4 new components to the page; [Leadspace with search](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-lead-space-search--default),
+[Table of contents - horizontal](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-table-of-contents--horizontal),
+[Card section offset](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-section-offset--default), and
+[CTA section with link list](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-cta-section--with-link-list). All components have
 implementation details in the linked Storybook Docs tab. The Docs tab has a link to the codesandbox example of each component, props table to showcase different variations possible, and other
 key information. This is a great place to look back to if you're ever stuck.
 
@@ -94,7 +94,7 @@ Import the following into `app.js`:
 import '@carbon/ibmdotcom-web-components/es/components/leadspace-with-search/index.js';
 ```
 
-Next, add the following code (which you can find in the `Leadspace with search` [Storybook Docs](https://www.ibm.com/standards/carbon/web-components/?path=/docs/components-lead-space-search--default)) within the `<dds-dotcom-shell-container>` tags in `index.html`:
+Next, add the following code (which you can find in the `Leadspace with search` [Storybook Docs](https://www.ibm.com/standards/carbon/v1/web-components/?path=/docs/components-lead-space-search--default)) within the `<dds-dotcom-shell-container>` tags in `index.html`:
 
 <!-- prettier-ignore-start -->
 ```html path=src/index.html

--- a/src/pages/developing/web-components-tutorial/step-3.mdx
+++ b/src/pages/developing/web-components-tutorial/step-3.mdx
@@ -68,16 +68,16 @@ The design illustrates each `Content block` sitting within a `Content section`.
 Each `Content block` will have various children components that will demonstrate the different types of customization.
 The following components that will be used in step 3 are:
 
-- [Content section](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-section--default)
-- [Content block](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-block--default)
-- [Content group](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-group--default)
-- [Content item](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-content-iten--default)
-- [Card group](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-group--default)
-- [Image](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-image--default)
-- [Image with caption](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-image-with-caption--default)
-- [CTA](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-cta--text)
-- [Card section offset](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-section-offset--default)
-- [Card in card](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-card-in-card--default)
+- [Content section](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-section--default)
+- [Content block](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-block--default)
+- [Content group](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-group--default)
+- [Content item](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-content-iten--default)
+- [Card group](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-group--default)
+- [Image](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-image--default)
+- [Image with caption](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-image-with-caption--default)
+- [CTA](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-cta--text)
+- [Card section offset](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-section-offset--default)
+- [Card in card](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-card-in-card--default)
 
 All the components have implementation details in the linked Storybook Docs tab. The Docs tab has a link to the codesandbox example of each component, props table to showcase different variations possible, and other
 key information. This is a great place to look back to if you're ever stuck.

--- a/src/pages/developing/web-components-tutorial/step-4.mdx
+++ b/src/pages/developing/web-components-tutorial/step-4.mdx
@@ -75,7 +75,7 @@ These components will be showcased at the bottom using the `Tabs` components, so
 The following Carbon components that will be used in step 4 are:
 
 - [Tag](https://web-components.carbondesignsystem.com/?path=/story/components-tag--default)
-- [Tag group](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-tag-group--default)
+- [Tag group](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-tag-group--default)
 - [Tabs](https://web-components.carbondesignsystem.com/?path=/story/components-tabs--default)
 - [Data table](https://web-components.carbondesignsystem.com/?path=/story/components-data-table--default)
 - [Dropdown](https://web-components.carbondesignsystem.com/?path=/story/components-dropdown--default)

--- a/src/pages/guidelines/right-to-left.mdx
+++ b/src/pages/guidelines/right-to-left.mdx
@@ -389,5 +389,5 @@ For React, see the
 on Storybook for details.
 
 For Web Components, see the
-[Enable right-to-left (RTL)](https://www.ibm.com/standards/carbon/web-components/?path=/docs/overview-enable-right-to-left-rtl--page)
+[Enable right-to-left (RTL)](https://www.ibm.com/standards/carbon/v1/web-components/?path=/docs/overview-enable-right-to-left-rtl--page)
 on Storybook for details.

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -137,9 +137,9 @@ possible for your page implementations.
   <Column colMd={4} colLg={4} noGutterSm>
    <ResourceCard
        color="dark"
-       title="Web components Storybook"
+       title="Web components Storybook v1"
        target="_blank"
-       href="https://www.ibm.com/standards/carbon/web-components/"
+       href="https://www.ibm.com/standards/carbon/v1/web-components/"
        >
 
 ![GitHub icon](../images/icon/storybook.svg)
@@ -149,7 +149,7 @@ possible for your page implementations.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     color="dark"
-    title="React components Storybook"
+    title="React components Storybook v1"
     target="_blank"
     href="https://www.ibm.com/standards/carbon/react/"
     >

--- a/src/pages/patterns/lead-space.mdx
+++ b/src/pages/patterns/lead-space.mdx
@@ -35,7 +35,7 @@ The lead space is positioned at the top of a web page and serves as the first si
 
 <InlineNotification>
 
-**Note that button group has been updated:** the primary button will appear first, followed by the tertiary button. All example images with two buttons are outdated, please reference the [Lead space storybook](https://www.ibm.com/standards/carbon/web-components/?path=/story/components-lead-space--super) for live examples.
+**Note that button group has been updated:** the primary button will appear first, followed by the tertiary button. All example images with two buttons are outdated, please reference the [Lead space storybook](https://www.ibm.com/standards/carbon/v1/web-components/?path=/story/components-lead-space--super) for live examples.
 
 </InlineNotification>
 

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -62,8 +62,8 @@ IBM.com.
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="Carbon for IBM.com Storybook Web Components"
-  href="https://www.ibm.com/standards/carbon/web-components"
+  subTitle="Carbon for IBM.com Storybook Web Components v1"
+  href="https://www.ibm.com/standards/carbon/v1/web-components"
   target="_blank"
 >
 
@@ -86,8 +86,8 @@ IBM.com.
 
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="Carbon for IBM.com Storybook React wrapper"
-  href="https://www.ibm.com/standards/carbon/web-components/react"
+  subTitle="Carbon for IBM.com Storybook React wrapper v1"
+  href="https://www.ibm.com/standards/carbon/v1/web-components/react"
   target="_blank"
 >
 


### PR DESCRIPTION
### Related Ticket(s)

N/A

### Description

This replaces all of the storybook links to point to the v1 links.
### Changelog

**Changed**

- Multiple files with storybook links
